### PR TITLE
PDF only with tutorial

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -61,7 +61,7 @@ locale_dirs = ['../locales', 'cpython/locales']  # relative to the sourcedir
 # So, we put all the documentation as a single file for now.
 _stdauthor = r'Guido van Rossum\\and the Python development team'
 latex_documents = [
-    ('contents', 'python-docs-es.tex', u'Documentación de Python en Español',
+    ('tutorial/index', 'python-docs-es.tex', u'Documentación de Python en Español',
      _stdauthor, 'manual'),
 ]
 


### PR DESCRIPTION
This PR shows an example of building *only* the Tutorial: [PDF](https://github.com/PyCampES/python-docs-es/files/4590591/python-docs-es-readthedocs-io-es-pdf.pdf).


cc @facundobatista @gilgamezh 

Related to #67 