### PR TITLE
Update repository URL

### DIFF
--- a/.overrides/CONTRIBUTING.rst
+++ b/.overrides/CONTRIBUTING.rst
@@ -27,7 +27,7 @@ Necesitamos *mucho* de tu ayuda para poder seguir adelante con este proyecto.
 
 #. Agrega el repositorio original como "upstream"::
 
-     git remote add upstream https://github.com/pycampes/python-docs-es.git
+     git remote add upstream https://github.com/python/python-docs-es.git
 
 #. Crea una rama nueva en base al artículo en el que vayas a trabajar.
    Por ejemplo, si vas a trabajar en el archivo ``glosario.po``, usa un nombre similar a::
@@ -118,7 +118,7 @@ Puedes ver el resultado con tu navegador de internet (Firefox, Chrome, etc) ejec
 Y luego accediendo a http://localhost:8000/
 
 
-.. _repositorio: https://github.com/PyCampES/python-docs-es
+.. _repositorio: https://github.com/python/python-docs-es
 .. _ayuda oficial de GitHub: https://help.github.com/es/github/getting-started-with-github/fork-a-repo
 .. _ayuda oficial de GitHub para crear un Pull Request: https://help.github.com/es/github/collaborating-with-issues-and-pull-requests/about-pull-requests
 .. _poedit: https://poedit.net/
@@ -126,4 +126,4 @@ Y luego accediendo a http://localhost:8000/
 .. _nuestro canal de Telegram: https://t.me/python_docs_es
 .. _Memoria de traducción: https://python-docs-es.readthedocs.io/page/translation-memory.html
 .. _la traducción al Portugués: https://docs.python.org/pt-br/3/
-.. _lista de issues en GitHub: https://github.com/PyCampES/python-docs-es/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+.. _lista de issues en GitHub: https://github.com/python/python-docs-es/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Spanish Translation of the Python Documentation
 ===============================================
 
-.. image:: https://travis-ci.org/PyCampES/python-docs-es.svg?branch=3.8 
-  :target: https://travis-ci.org/PyCampES/python-docs-es
+.. image:: https://travis-ci.org/python/python-docs-es.svg?branch=3.8
+  :target: https://travis-ci.org/python/python-docs-es
   :alt: Build Status
 
 .. image:: https://readthedocs.org/projects/python-docs-es/badge/?version=3.8


### PR DESCRIPTION
I just updated the URLs that are visible for now.

However, we have the URL in the header of each .po file as well. Changing them all will introduce conflicts to already opened PRs and people will need to resolve them. I think it's not need for now to introduce that problem.