### PR TITLE
remove the requirement to sort the dict file.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,3 @@ repos:
     hooks:
     -   id: pospell
         args: ['--personal-dict', 'dict', '--modified', '--language', 'es_ES', '--language', 'es_AR']
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
-    hooks:
-    -   id: file-contents-sorter
-        files: dict

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 script:
   - powrap --check --quiet **/*.po
   - pospell -p dict -l es_AR -l es_ES **/*.po
+  - make dict_dups
   - make build
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ help:
 	@echo " spell        Check spelling"
 	@echo " wrap         Wrap all the PO files to a fixed column width"
 	@echo " progress     To compute current progression on the tutorial"
+	@echo " dict_dups	Check duplicated entries on the dict"
 	@echo ""
 
 
@@ -94,3 +95,17 @@ spell: venv
 .PHONY: wrap
 wrap: venv
 	$(VENV)/bin/powrap **/*.po
+
+.PHONY: dict_dups
+SHELL:=/bin/bash
+.ONESHELL:
+dict_dups:
+	if [[ $$(cat dict| sort | uniq -dc) ]]; then\
+		echo -e "\n\n\n ####################### \n\n\n"
+		echo "duplicated lines in the dict file"
+		uniq -dc dict
+		exit 1
+	else
+		echo "no duplicated lines"
+		exit 0
+	fi

--- a/dict
+++ b/dict
@@ -26,7 +26,6 @@ Cookbook
 Ctrl
 Cython
 Distutils
-Distutils
 FLTK
 Fibonacci
 Finder
@@ -41,7 +40,6 @@ Greg
 Gtk+
 HTML
 Hammond
-Hat
 Hat
 Henstridge
 Hewlett
@@ -65,7 +63,6 @@ Lucasfilm
 Mac
 MacOS
 Macintosh
-Mandrake
 Mandrake
 Mark
 Microsoft
@@ -106,10 +103,8 @@ SciPy
 SimpleFileExFlags
 Smalltalk
 Solaris
-Solaris
 Spot
 Stein
-subdirectorios
 TCP
 Tcl
 Tix
@@ -143,7 +138,6 @@ b
 backspace
 bash
 batch
-bdist
 bdist
 big-endian
 bloqueante
@@ -183,14 +177,11 @@ criptográficamente
 curses
 customización
 customizarlo
-códec
 datagramas
 debugueando
 default
 desasignar
-descompresor
 deserialización
-deserializar
 desreferenciar
 desalojable
 desambiguar
@@ -203,11 +194,7 @@ descargable
 desasignarán
 desasignador
 desasignadores
-descargable
-desasignada
-descargable
 descompresor
-deserialización
 deserializar
 desinstalador
 designadores
@@ -342,7 +329,6 @@ naif
 nonlocal
 object
 obsérvese
-option
 or
 ordenables
 path
@@ -350,20 +336,14 @@ pathlib
 multiprocesamiento
 mutex
 mxBase
-mxBase
 naíf
 naífs
 ncurses
-nonlocal
 normalización
-object
 operando
-operandos
 onexit
-operandos
 option
 operandos
-or
 os
 pads
 parsea
@@ -438,7 +418,6 @@ s
 script
 scripting
 scripts
-sdux
 sdux
 search
 secuencialmente


### PR DESCRIPTION
Debido a que hemos sort del archivo del diccionario con el pre-commit esto esta creando un montón de conflictos a la hora de hacer merge de un nuevo PR.
Sí unicamente agregamos palabras nuevas al final del archivo esos conflictos van a producirse muy pocas veces.

- eliminé el pre-commit que hace sort 
- agregué un chequeo en travis para buscar duplicados en el diccionario (va a fallar la primera vez)
