### PR TITLE
fix dict_dups check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,10 +100,10 @@ wrap: venv
 SHELL:=/bin/bash
 .ONESHELL:
 dict_dups:
-	if [[ $$(cat dict| sort | uniq -dc) ]]; then\
-		echo -e "\n\n\n ####################### \n\n\n"
+	if [[ $$(cat dict| sort | uniq -dc) ]]; then
+		echo -e "\n #######################\n"
 		echo "duplicated lines in the dict file"
-		uniq -dc dict
+		sort dict | uniq -dc |sort -h
 		exit 1
 	else
 		echo "no duplicated lines"


### PR DESCRIPTION
Fix para el check de duplicados.

@humitos estaba proponiendo removerlo. Yo creo que nos agrega un mínimo chequeo de que alguien no agrega mil cosas random. Pero si les parece que no aporta lo sacamos.

Alguien sabe cómo agregar un comando bash en un pre-commit? podríamos moverlo ahí tal vez.

Si les parece mejor sacarlo avisen y lo hago en este PR