### PR TITLE
Use one dictionary per file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Doc/CONTRIBUTING.rst
 Doc/translation-memory.rst
 Doc/upgrade-python-version.rst
 locales/
+dict.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.overrides/faq.rst
+++ b/.overrides/faq.rst
@@ -61,6 +61,18 @@ Estamos trabajando para unificar el uso de un mismo set de diccionarios de espa�
 pero por el momento el chequeo que hacemos es con los diccionarios es_AR y es_ES.
 
 
+¿Cómo agrego una palabra al diccionario?
+----------------------------------------
+
+Si ``pospell`` falla diciendo que no conoce una palabra, pero estamos seguros que esa palabra está bien escrita,
+debemos agregarla al diccionario que ``pospell`` usa internamente para comprobar las palabras.
+
+Para eso debes editar (o crear, si no existe) el archivo ``<archivopo>.txt`` dentro del direcorio ``dictionaries``
+y agregar esa palabra al final de este archivo.
+Nota que debes reemplazar ``<archivopo>`` por el nombre del archivo que estés traduciendo.
+Por ejemplo, si estás traduciendo ``library/decimal.po``, debes editar/crear el archivos ``dictionaries/library_decimal.txt``.
+
+
 ¿Cómo puedo configurar git para manejar correctamente los finales de línea en Windows?
 --------------------------------------------------------------------------------------
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ install:
   - powrap --version
 script:
   - powrap --check --quiet **/*.po
-  - pospell -p dict -l es_AR -l es_ES **/*.po
+  - cat dict dictionaries/*.txt > dict.txt
+  - pospell -p dict.txt -l es_AR -l es_ES **/*.po
   - make build
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,8 @@ progress: venv
 
 .PHONY: spell
 spell: venv
-	$(VENV)/bin/pospell -p dict -l es_ES **/*.po
+	cat dict dictionaries/*.txt > dict.txt
+	$(VENV)/bin/pospell -p dict.txt -l es_ES **/*.po
 
 
 .PHONY: wrap


### PR DESCRIPTION
We had a lot of conflict using a shared `dict` file for all the PRs. We are
using a simpler approach now where we create a dictionary file per .po
translated to avoid this conflicts.

When calling pospell, we concatenate all these files together and use the result
to call pospell properly.