### PR TITLE
Arreglar la union de diccionarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,8 @@ progress: venv
 
 .PHONY: spell
 spell: venv
+        # 'cat' tenia el problema que algunos archivos no tenían una nueva línea al final
+        # 'awk 1' agregará una nueva línea en caso que falte.
 	awk 1 dict dictionaries/*.txt > dict.txt
 	$(VENV)/bin/pospell -p dict.txt -l es_ES **/*.po
 

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ progress: venv
 
 .PHONY: spell
 spell: venv
-	cat dict dictionaries/*.txt > dict.txt
+	awk 1 dict dictionaries/*.txt > dict.txt
 	$(VENV)/bin/pospell -p dict.txt -l es_ES **/*.po
 
 


### PR DESCRIPTION
`awk 1` agregará un salto de línea
a los archivos que no la tengan,
arreglando los problemas que hemos tenido
desde la implementación de los diccionarios
por archivo.