### PR TITLE
Cambiar instrucciones de travis como Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - powrap --version
 script:
   - powrap --check --quiet **/*.po
-  - cat dict dictionaries/*.txt > dict.txt
+  - awk 1 dict dictionaries/*.txt > dict.txt
   - pospell -p dict.txt -l es_AR -l es_ES **/*.po
   - make build
 branches:


### PR DESCRIPTION
Después del merge de PR #619, el archivo de configuración
de travis no fue actualizado como corresponde.
(cc @gilgamezh  se me pasó esto cuando hice el otro arreglo)
@katialira fue culpa mía al no actualizar la instrucción de travis.