### PR TITLE
Agregar 'tabulate' como dependencia

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pre-commit
 sphinx-autorun
 sphinxemoji
 sphinx-tabs
+tabulate


### PR DESCRIPTION
Para ejecutar `scripts/find_in_po.py` python indica que no encuentra el módulo `tabulate`

~~~
$ python scripts/find_in_po.py
Traceback (most recent call last):
  File "scripts/find_in_po.py", line 10, in <module>
    from tabulate import tabulate   # fades
ModuleNotFoundError: No module named 'tabulate'
~~~

Me parece que se debería de añadir 'tabulate' como dependencia en requirements.txt.