### PR TITLE
Minor fixes in Makefile/Cambios menores en Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ help:
 #        treated as errors, which is good to skip simple Sphinx syntax mistakes.
 .PHONY: build
 build: setup
-		PYTHONWARNINGS=ignore::FutureWarning $(VENV)/bin/sphinx-build -j auto -W --keep-going -b html -d $(OUTPUT_DOCTREE) -D language=$(LANGUAGE) . $(OUTPUT_HTML) && \
-		@echo "Success! Open file://`pwd`/$(OUTPUT_HTML)/index.html, " \
-					"or run 'make serve' to see them in http://localhost:8000";
+	PYTHONWARNINGS=ignore::FutureWarning $(VENV)/bin/sphinx-build -j auto -W --keep-going -b html -d $(OUTPUT_DOCTREE) -D language=$(LANGUAGE) . $(OUTPUT_HTML) && \
+		echo "Success! Open file://`pwd`/$(OUTPUT_HTML)/index.html, " \
+			"or run 'make serve' to see them in http://localhost:8000";
 
 
 # setup: After running "venv" target, prepare that virtual environment with
@@ -78,7 +78,7 @@ serve:
 #        could have been created by the actions in other targets of this script
 .PHONY: clean
 clean:
-	rm -fr $(VENV)
+	rm -rf $(VENV)
 	rm -rf $(POSPELL_TMP_DIR)
 	find -name '*.mo' -delete
 


### PR DESCRIPTION
- Fix indent in `make build`.
- `@echo` is failing in `make build` because is followed from `&&`. `@` usage in Makefiles only is possible at the beggining of a command.
- `rm -fr $(VENV)` replaced with `rm -rf $(VENV)` to keep consistence in `make clean`.

---

- Corregida indentación en `make build`.
- `@echo` está fallando en `make build` porque está seguido de `&&`. El uso de `@` en Makefiles sólo es posible al principio de cada comando.
- Reemplazado `rm -fr $(VENV)` con `rm -rf $(VENV)` para mantener la consistencia en `make clean`.