### PR TITLE
Actualizado hook 'pospell' de pre-commit para apuntar al repositorio de pospell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,8 @@ repos:
         entry: ./scripts/merge-dicts.sh
         language: script
 # This one requires package ``hunspell-es_es`` in Archlinux
--   repo: https://github.com/humitos/pospell
-    rev: pre-commit
+-   repo: https://github.com/JulienPalard/pospell
+    rev: v1.0.5
     hooks:
     -   id: pospell
         args: ['--personal-dict', 'dict.txt', '--modified', '--language', 'es_ES', '--language', 'es_AR']

--- a/dict
+++ b/dict
@@ -127,6 +127,7 @@ Fortran
 Foundation
 Fourier
 FrameMaker
+Fred
 Fredrik
 G
 Friedl
@@ -1453,3 +1454,4 @@ formfeed
 reintrodujo
 radix
 léxicamente
+Sphinx

--- a/dict
+++ b/dict
@@ -127,7 +127,6 @@ Fortran
 Foundation
 Fourier
 FrameMaker
-Fred
 Fredrik
 G
 Friedl
@@ -1454,4 +1453,3 @@ formfeed
 reintrodujo
 radix
 léxicamente
-Sphinx


### PR DESCRIPTION
Los hooks pre-commit [fueron añadidos al repositorio de pospell](https://github.com/JulienPalard/pospell/pull/14), por lo tanto, no hay razón para tirar más del fork de @humitos. He optado por la última release como `rev`.
