### PR TITLE
Actualizados links a repositorio

### DIFF
--- a/.overrides/tools/templates/customsourcelink.html
+++ b/.overrides/tools/templates/customsourcelink.html
@@ -4,7 +4,7 @@
     <ul class="this-page-menu">
         <li><a href="{{ pathto('bugs') }}">{% trans %}Report a Bug{% endtrans %}</a></li>
         <li>
-            <a href="https://github.com/PyCampES/python-docs-es/blob/{{ version }}/{{ sourcename|replace('.rst.txt', '.po') }}"
+            <a href="https://github.com/python/python-docs-es/blob/{{ version }}/{{ sourcename|replace('.rst.txt', '.po') }}"
                rel="nofollow">{{ _('Show Source') }}
             </a>
         </li>

--- a/.overrides/tools/templates/indexsidebar.html
+++ b/.overrides/tools/templates/indexsidebar.html
@@ -8,5 +8,5 @@
 <ul>
   <li><a href="https://mail.python.org/mailman3/lists/docs-es.python.org/">Lista de correos</a></li>
   <li><a href="https://t.me/python_docs_es">Canal de Télegram</a></li>
-  <li><a href="https://github.com/PyCampES/python-docs-es">Repositorio GitHub</a></li>
+  <li><a href="https://github.com/python/python-docs-es">Repositorio GitHub</a></li>
 </ul>

--- a/about.po
+++ b/about.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/bugs.po
+++ b/bugs.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/abstract.po
+++ b/c-api/abstract.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/c-api/allocation.po
+++ b/c-api/allocation.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/c-api/apiabiversion.po
+++ b/c-api/apiabiversion.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/c-api/arg.po
+++ b/c-api/arg.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/bool.po
+++ b/c-api/bool.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/c-api/buffer.po
+++ b/c-api/buffer.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/bytearray.po
+++ b/c-api/bytearray.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/bytes.po
+++ b/c-api/bytes.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/capsule.po
+++ b/c-api/capsule.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/cell.po
+++ b/c-api/cell.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/code.po
+++ b/c-api/code.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/codec.po
+++ b/c-api/codec.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/complex.po
+++ b/c-api/complex.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/concrete.po
+++ b/c-api/concrete.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/contextvars.po
+++ b/c-api/contextvars.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/conversion.po
+++ b/c-api/conversion.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/coro.po
+++ b/c-api/coro.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/datetime.po
+++ b/c-api/datetime.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/descriptor.po
+++ b/c-api/descriptor.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/c-api/dict.po
+++ b/c-api/dict.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/exceptions.po
+++ b/c-api/exceptions.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/file.po
+++ b/c-api/file.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/float.po
+++ b/c-api/float.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/function.po
+++ b/c-api/function.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/gcsupport.po
+++ b/c-api/gcsupport.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/gen.po
+++ b/c-api/gen.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/import.po
+++ b/c-api/import.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/index.po
+++ b/c-api/index.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/c-api/init.po
+++ b/c-api/init.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/intro.po
+++ b/c-api/intro.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/iter.po
+++ b/c-api/iter.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/iterator.po
+++ b/c-api/iterator.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/c-api/list.po
+++ b/c-api/list.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/long.po
+++ b/c-api/long.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/mapping.po
+++ b/c-api/mapping.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/marshal.po
+++ b/c-api/marshal.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/memory.po
+++ b/c-api/memory.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/memoryview.po
+++ b/c-api/memoryview.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/method.po
+++ b/c-api/method.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/module.po
+++ b/c-api/module.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/none.po
+++ b/c-api/none.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/c-api/number.po
+++ b/c-api/number.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/objbuffer.po
+++ b/c-api/objbuffer.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/c-api/object.po
+++ b/c-api/object.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/objimpl.po
+++ b/c-api/objimpl.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/c-api/refcounting.po
+++ b/c-api/refcounting.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/reflection.po
+++ b/c-api/reflection.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/sequence.po
+++ b/c-api/sequence.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/set.po
+++ b/c-api/set.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/slice.po
+++ b/c-api/slice.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/stable.po
+++ b/c-api/stable.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/c-api/structures.po
+++ b/c-api/structures.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/c-api/sys.po
+++ b/c-api/sys.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/tuple.po
+++ b/c-api/tuple.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/type.po
+++ b/c-api/type.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/typeobj.po
+++ b/c-api/typeobj.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/unicode.po
+++ b/c-api/unicode.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/utilities.po
+++ b/c-api/utilities.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/c-api/veryhigh.po
+++ b/c-api/veryhigh.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/c-api/weakref.po
+++ b/c-api/weakref.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/contents.po
+++ b/contents.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/copyright.po
+++ b/copyright.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/distributing/index.po
+++ b/distributing/index.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/distutils/apiref.po
+++ b/distutils/apiref.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/distutils/builtdist.po
+++ b/distutils/builtdist.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/distutils/commandref.po
+++ b/distutils/commandref.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/distutils/configfile.po
+++ b/distutils/configfile.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/distutils/examples.po
+++ b/distutils/examples.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/distutils/extending.po
+++ b/distutils/extending.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/distutils/index.po
+++ b/distutils/index.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/distutils/introduction.po
+++ b/distutils/introduction.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/distutils/packageindex.po
+++ b/distutils/packageindex.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/distutils/setupscript.po
+++ b/distutils/setupscript.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/distutils/sourcedist.po
+++ b/distutils/sourcedist.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/distutils/uploading.po
+++ b/distutils/uploading.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/extending/building.po
+++ b/extending/building.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/extending/embedding.po
+++ b/extending/embedding.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/extending/extending.po
+++ b/extending/extending.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/extending/index.po
+++ b/extending/index.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/extending/newtypes.po
+++ b/extending/newtypes.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/extending/newtypes_tutorial.po
+++ b/extending/newtypes_tutorial.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/extending/windows.po
+++ b/extending/windows.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/faq/design.po
+++ b/faq/design.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/faq/extending.po
+++ b/faq/extending.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/faq/general.po
+++ b/faq/general.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/faq/gui.po
+++ b/faq/gui.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/faq/index.po
+++ b/faq/index.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/faq/installed.po
+++ b/faq/installed.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/faq/library.po
+++ b/faq/library.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/faq/programming.po
+++ b/faq/programming.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/faq/windows.po
+++ b/faq/windows.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/glossary.po
+++ b/glossary.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/howto/argparse.po
+++ b/howto/argparse.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/howto/clinic.po
+++ b/howto/clinic.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/howto/cporting.po
+++ b/howto/cporting.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/howto/curses.po
+++ b/howto/curses.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/howto/descriptor.po
+++ b/howto/descriptor.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/howto/functional.po
+++ b/howto/functional.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/howto/index.po
+++ b/howto/index.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/howto/instrumentation.po
+++ b/howto/instrumentation.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/howto/ipaddress.po
+++ b/howto/ipaddress.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/howto/logging-cookbook.po
+++ b/howto/logging-cookbook.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/howto/logging.po
+++ b/howto/logging.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/howto/pyporting.po
+++ b/howto/pyporting.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/howto/regex.po
+++ b/howto/regex.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/howto/sockets.po
+++ b/howto/sockets.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/howto/sorting.po
+++ b/howto/sorting.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/howto/unicode.po
+++ b/howto/unicode.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/howto/urllib2.po
+++ b/howto/urllib2.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/install/index.po
+++ b/install/index.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/installing/index.po
+++ b/installing/index.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/2to3.po
+++ b/library/2to3.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/__future__.po
+++ b/library/__future__.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/__main__.po
+++ b/library/__main__.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/_dummy_thread.po
+++ b/library/_dummy_thread.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/_thread.po
+++ b/library/_thread.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/abc.po
+++ b/library/abc.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/aifc.po
+++ b/library/aifc.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/allos.po
+++ b/library/allos.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/archiving.po
+++ b/library/archiving.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/argparse.po
+++ b/library/argparse.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/array.po
+++ b/library/array.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/ast.po
+++ b/library/ast.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/asynchat.po
+++ b/library/asynchat.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/asyncio-api-index.po
+++ b/library/asyncio-api-index.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/asyncio-dev.po
+++ b/library/asyncio-dev.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/asyncio-eventloop.po
+++ b/library/asyncio-eventloop.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/asyncio-exceptions.po
+++ b/library/asyncio-exceptions.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/asyncio-future.po
+++ b/library/asyncio-future.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/asyncio-llapi-index.po
+++ b/library/asyncio-llapi-index.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/asyncio-platforms.po
+++ b/library/asyncio-platforms.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/asyncio-policy.po
+++ b/library/asyncio-policy.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/asyncio-protocol.po
+++ b/library/asyncio-protocol.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/asyncio-queue.po
+++ b/library/asyncio-queue.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/asyncio-stream.po
+++ b/library/asyncio-stream.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/asyncio-subprocess.po
+++ b/library/asyncio-subprocess.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/asyncio-sync.po
+++ b/library/asyncio-sync.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/asyncio-task.po
+++ b/library/asyncio-task.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/asyncio.po
+++ b/library/asyncio.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/asyncore.po
+++ b/library/asyncore.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/atexit.po
+++ b/library/atexit.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/audioop.po
+++ b/library/audioop.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/base64.po
+++ b/library/base64.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/bdb.po
+++ b/library/bdb.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/binary.po
+++ b/library/binary.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/binascii.po
+++ b/library/binascii.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/binhex.po
+++ b/library/binhex.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/bisect.po
+++ b/library/bisect.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/builtins.po
+++ b/library/builtins.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/bz2.po
+++ b/library/bz2.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 # Santiago E Fraire Willemoes <santiwilly@gmail.com>, 2020.
 #

--- a/library/calendar.po
+++ b/library/calendar.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/cgi.po
+++ b/library/cgi.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/cgitb.po
+++ b/library/cgitb.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/chunk.po
+++ b/library/chunk.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/cmath.po
+++ b/library/cmath.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/cmd.po
+++ b/library/cmd.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/code.po
+++ b/library/code.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/codecs.po
+++ b/library/codecs.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/codeop.po
+++ b/library/codeop.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/collections.abc.po
+++ b/library/collections.abc.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/collections.po
+++ b/library/collections.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/colorsys.po
+++ b/library/colorsys.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/compileall.po
+++ b/library/compileall.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/concurrency.po
+++ b/library/concurrency.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/concurrent.futures.po
+++ b/library/concurrent.futures.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/concurrent.po
+++ b/library/concurrent.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/configparser.po
+++ b/library/configparser.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/constants.po
+++ b/library/constants.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/contextlib.po
+++ b/library/contextlib.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/contextvars.po
+++ b/library/contextvars.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/copy.po
+++ b/library/copy.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/copyreg.po
+++ b/library/copyreg.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/crypt.po
+++ b/library/crypt.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/crypto.po
+++ b/library/crypto.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/csv.po
+++ b/library/csv.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/ctypes.po
+++ b/library/ctypes.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/curses.ascii.po
+++ b/library/curses.ascii.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/curses.panel.po
+++ b/library/curses.panel.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/curses.po
+++ b/library/curses.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/custominterp.po
+++ b/library/custominterp.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/dataclasses.po
+++ b/library/dataclasses.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/datatypes.po
+++ b/library/datatypes.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/datetime.po
+++ b/library/datetime.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/dbm.po
+++ b/library/dbm.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/debug.po
+++ b/library/debug.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/decimal.po
+++ b/library/decimal.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/development.po
+++ b/library/development.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/difflib.po
+++ b/library/difflib.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/dis.po
+++ b/library/dis.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/distribution.po
+++ b/library/distribution.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/distutils.po
+++ b/library/distutils.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/doctest.po
+++ b/library/doctest.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/dummy_threading.po
+++ b/library/dummy_threading.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/email.charset.po
+++ b/library/email.charset.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/email.compat32-message.po
+++ b/library/email.compat32-message.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/email.contentmanager.po
+++ b/library/email.contentmanager.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/email.encoders.po
+++ b/library/email.encoders.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/email.errors.po
+++ b/library/email.errors.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/email.examples.po
+++ b/library/email.examples.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/email.generator.po
+++ b/library/email.generator.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/email.header.po
+++ b/library/email.header.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/email.headerregistry.po
+++ b/library/email.headerregistry.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/email.iterators.po
+++ b/library/email.iterators.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/email.message.po
+++ b/library/email.message.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/email.mime.po
+++ b/library/email.mime.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/email.parser.po
+++ b/library/email.parser.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/email.po
+++ b/library/email.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/email.policy.po
+++ b/library/email.policy.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/email.utils.po
+++ b/library/email.utils.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/ensurepip.po
+++ b/library/ensurepip.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/enum.po
+++ b/library/enum.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/errno.po
+++ b/library/errno.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/exceptions.po
+++ b/library/exceptions.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/faulthandler.po
+++ b/library/faulthandler.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/fcntl.po
+++ b/library/fcntl.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/filecmp.po
+++ b/library/filecmp.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/fileformats.po
+++ b/library/fileformats.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/fileinput.po
+++ b/library/fileinput.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/filesys.po
+++ b/library/filesys.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/fnmatch.po
+++ b/library/fnmatch.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/formatter.po
+++ b/library/formatter.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/fractions.po
+++ b/library/fractions.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/frameworks.po
+++ b/library/frameworks.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/ftplib.po
+++ b/library/ftplib.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/functional.po
+++ b/library/functional.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/functions.po
+++ b/library/functions.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/functools.po
+++ b/library/functools.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/gc.po
+++ b/library/gc.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/getopt.po
+++ b/library/getopt.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/getpass.po
+++ b/library/getpass.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/gettext.po
+++ b/library/gettext.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/glob.po
+++ b/library/glob.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/grp.po
+++ b/library/grp.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/gzip.po
+++ b/library/gzip.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/hashlib.po
+++ b/library/hashlib.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/heapq.po
+++ b/library/heapq.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/hmac.po
+++ b/library/hmac.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/html.entities.po
+++ b/library/html.entities.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/html.parser.po
+++ b/library/html.parser.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/html.po
+++ b/library/html.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/http.client.po
+++ b/library/http.client.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/http.cookiejar.po
+++ b/library/http.cookiejar.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/http.cookies.po
+++ b/library/http.cookies.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/http.po
+++ b/library/http.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/http.server.po
+++ b/library/http.server.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/i18n.po
+++ b/library/i18n.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/idle.po
+++ b/library/idle.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/imaplib.po
+++ b/library/imaplib.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/imghdr.po
+++ b/library/imghdr.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/imp.po
+++ b/library/imp.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/importlib.po
+++ b/library/importlib.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/index.po
+++ b/library/index.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/inspect.po
+++ b/library/inspect.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/internet.po
+++ b/library/internet.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/intro.po
+++ b/library/intro.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/io.po
+++ b/library/io.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/ipaddress.po
+++ b/library/ipaddress.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/ipc.po
+++ b/library/ipc.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/itertools.po
+++ b/library/itertools.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/json.po
+++ b/library/json.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/keyword.po
+++ b/library/keyword.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/language.po
+++ b/library/language.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/linecache.po
+++ b/library/linecache.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/locale.po
+++ b/library/locale.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/logging.config.po
+++ b/library/logging.config.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/logging.handlers.po
+++ b/library/logging.handlers.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/logging.po
+++ b/library/logging.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/lzma.po
+++ b/library/lzma.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/macpath.po
+++ b/library/macpath.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/mailbox.po
+++ b/library/mailbox.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/mailcap.po
+++ b/library/mailcap.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/markup.po
+++ b/library/markup.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/marshal.po
+++ b/library/marshal.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/math.po
+++ b/library/math.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/mimetypes.po
+++ b/library/mimetypes.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/misc.po
+++ b/library/misc.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/mm.po
+++ b/library/mm.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/mmap.po
+++ b/library/mmap.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/modulefinder.po
+++ b/library/modulefinder.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/modules.po
+++ b/library/modules.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/msilib.po
+++ b/library/msilib.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/msvcrt.po
+++ b/library/msvcrt.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/multiprocessing.po
+++ b/library/multiprocessing.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/netdata.po
+++ b/library/netdata.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/netrc.po
+++ b/library/netrc.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/nis.po
+++ b/library/nis.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/nntplib.po
+++ b/library/nntplib.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/numbers.po
+++ b/library/numbers.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/numeric.po
+++ b/library/numeric.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/operator.po
+++ b/library/operator.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/optparse.po
+++ b/library/optparse.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/os.path.po
+++ b/library/os.path.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/os.po
+++ b/library/os.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/ossaudiodev.po
+++ b/library/ossaudiodev.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/othergui.po
+++ b/library/othergui.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/parser.po
+++ b/library/parser.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/pathlib.po
+++ b/library/pathlib.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/pdb.po
+++ b/library/pdb.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/persistence.po
+++ b/library/persistence.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/pickle.po
+++ b/library/pickle.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/pickletools.po
+++ b/library/pickletools.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/pipes.po
+++ b/library/pipes.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/pkgutil.po
+++ b/library/pkgutil.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/platform.po
+++ b/library/platform.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/plistlib.po
+++ b/library/plistlib.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/poplib.po
+++ b/library/poplib.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/posix.po
+++ b/library/posix.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/pprint.po
+++ b/library/pprint.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/profile.po
+++ b/library/profile.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/pty.po
+++ b/library/pty.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/pwd.po
+++ b/library/pwd.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/py_compile.po
+++ b/library/py_compile.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/pyclbr.po
+++ b/library/pyclbr.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/pydoc.po
+++ b/library/pydoc.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/pyexpat.po
+++ b/library/pyexpat.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/python.po
+++ b/library/python.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/queue.po
+++ b/library/queue.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/quopri.po
+++ b/library/quopri.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/re.po
+++ b/library/re.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/readline.po
+++ b/library/readline.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/reprlib.po
+++ b/library/reprlib.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/resource.po
+++ b/library/resource.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/rlcompleter.po
+++ b/library/rlcompleter.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/runpy.po
+++ b/library/runpy.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/sched.po
+++ b/library/sched.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/secrets.po
+++ b/library/secrets.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/select.po
+++ b/library/select.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/selectors.po
+++ b/library/selectors.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/shelve.po
+++ b/library/shelve.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/shlex.po
+++ b/library/shlex.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/shutil.po
+++ b/library/shutil.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/signal.po
+++ b/library/signal.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/site.po
+++ b/library/site.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/smtpd.po
+++ b/library/smtpd.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/smtplib.po
+++ b/library/smtplib.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/sndhdr.po
+++ b/library/sndhdr.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/socket.po
+++ b/library/socket.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/socketserver.po
+++ b/library/socketserver.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/spwd.po
+++ b/library/spwd.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/sqlite3.po
+++ b/library/sqlite3.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/ssl.po
+++ b/library/ssl.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/stat.po
+++ b/library/stat.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/statistics.po
+++ b/library/statistics.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/stdtypes.po
+++ b/library/stdtypes.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/string.po
+++ b/library/string.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/stringprep.po
+++ b/library/stringprep.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/struct.po
+++ b/library/struct.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/subprocess.po
+++ b/library/subprocess.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/sunau.po
+++ b/library/sunau.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/superseded.po
+++ b/library/superseded.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/symbol.po
+++ b/library/symbol.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/symtable.po
+++ b/library/symtable.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/sys.po
+++ b/library/sys.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/sysconfig.po
+++ b/library/sysconfig.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/syslog.po
+++ b/library/syslog.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/tabnanny.po
+++ b/library/tabnanny.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/tarfile.po
+++ b/library/tarfile.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/telnetlib.po
+++ b/library/telnetlib.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/tempfile.po
+++ b/library/tempfile.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/termios.po
+++ b/library/termios.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/test.po
+++ b/library/test.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/text.po
+++ b/library/text.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/textwrap.po
+++ b/library/textwrap.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/threading.po
+++ b/library/threading.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/time.po
+++ b/library/time.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/timeit.po
+++ b/library/timeit.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/tk.po
+++ b/library/tk.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/tkinter.po
+++ b/library/tkinter.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/tkinter.scrolledtext.po
+++ b/library/tkinter.scrolledtext.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/tkinter.tix.po
+++ b/library/tkinter.tix.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/tkinter.ttk.po
+++ b/library/tkinter.ttk.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/token.po
+++ b/library/token.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/tokenize.po
+++ b/library/tokenize.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/trace.po
+++ b/library/trace.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/traceback.po
+++ b/library/traceback.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/tracemalloc.po
+++ b/library/tracemalloc.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/tty.po
+++ b/library/tty.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/turtle.po
+++ b/library/turtle.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/types.po
+++ b/library/types.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/typing.po
+++ b/library/typing.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/undoc.po
+++ b/library/undoc.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/unicodedata.po
+++ b/library/unicodedata.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/unittest.mock-examples.po
+++ b/library/unittest.mock-examples.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/unittest.mock.po
+++ b/library/unittest.mock.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/unittest.po
+++ b/library/unittest.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/unix.po
+++ b/library/unix.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/urllib.error.po
+++ b/library/urllib.error.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/urllib.parse.po
+++ b/library/urllib.parse.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/urllib.po
+++ b/library/urllib.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/urllib.request.po
+++ b/library/urllib.request.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/urllib.robotparser.po
+++ b/library/urllib.robotparser.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/uu.po
+++ b/library/uu.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/uuid.po
+++ b/library/uuid.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/venv.po
+++ b/library/venv.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/warnings.po
+++ b/library/warnings.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/wave.po
+++ b/library/wave.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/weakref.po
+++ b/library/weakref.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/webbrowser.po
+++ b/library/webbrowser.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/windows.po
+++ b/library/windows.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/winreg.po
+++ b/library/winreg.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/winsound.po
+++ b/library/winsound.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/wsgiref.po
+++ b/library/wsgiref.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/xdrlib.po
+++ b/library/xdrlib.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/xml.dom.minidom.po
+++ b/library/xml.dom.minidom.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/xml.dom.po
+++ b/library/xml.dom.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/xml.dom.pulldom.po
+++ b/library/xml.dom.pulldom.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/xml.etree.elementtree.po
+++ b/library/xml.etree.elementtree.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/xml.po
+++ b/library/xml.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/xml.sax.handler.po
+++ b/library/xml.sax.handler.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/xml.sax.po
+++ b/library/xml.sax.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/xml.sax.reader.po
+++ b/library/xml.sax.reader.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/xml.sax.utils.po
+++ b/library/xml.sax.utils.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/xmlrpc.client.po
+++ b/library/xmlrpc.client.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/xmlrpc.po
+++ b/library/xmlrpc.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/xmlrpc.server.po
+++ b/library/xmlrpc.server.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/library/zipapp.po
+++ b/library/zipapp.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/library/zipfile.po
+++ b/library/zipfile.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/library/zipimport.po
+++ b/library/zipimport.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/library/zlib.po
+++ b/library/zlib.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/license.po
+++ b/license.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/reference/compound_stmts.po
+++ b/reference/compound_stmts.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/reference/datamodel.po
+++ b/reference/datamodel.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/reference/executionmodel.po
+++ b/reference/executionmodel.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/reference/expressions.po
+++ b/reference/expressions.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/reference/grammar.po
+++ b/reference/grammar.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/reference/import.po
+++ b/reference/import.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/reference/index.po
+++ b/reference/index.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/reference/introduction.po
+++ b/reference/introduction.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/reference/lexical_analysis.po
+++ b/reference/lexical_analysis.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/reference/simple_stmts.po
+++ b/reference/simple_stmts.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/reference/toplevel_components.po
+++ b/reference/toplevel_components.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/scripts/create_issue.py
+++ b/scripts/create_issue.py
@@ -17,7 +17,7 @@ pofile = PoFileStats(Path(pofilename))
 
 g = Github(os.environ.get('GITHUB_TOKEN'))
 
-repo = g.get_repo('PyCampES/python-docs-es')
+repo = g.get_repo('python/python-docs-es')
 
 
 issues = repo.get_issues(state='all')

--- a/sphinx.po
+++ b/sphinx.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/tutorial/appendix.po
+++ b/tutorial/appendix.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/tutorial/appetite.po
+++ b/tutorial/appetite.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/tutorial/classes.po
+++ b/tutorial/classes.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/tutorial/controlflow.po
+++ b/tutorial/controlflow.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/tutorial/datastructures.po
+++ b/tutorial/datastructures.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/tutorial/errors.po
+++ b/tutorial/errors.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/tutorial/floatingpoint.po
+++ b/tutorial/floatingpoint.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/tutorial/index.po
+++ b/tutorial/index.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/tutorial/inputoutput.po
+++ b/tutorial/inputoutput.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/tutorial/interactive.po
+++ b/tutorial/interactive.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/tutorial/interpreter.po
+++ b/tutorial/interpreter.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/tutorial/introduction.po
+++ b/tutorial/introduction.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/tutorial/modules.po
+++ b/tutorial/modules.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/tutorial/stdlib.po
+++ b/tutorial/stdlib.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/tutorial/stdlib2.po
+++ b/tutorial/stdlib2.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 msgid ""
 msgstr ""

--- a/tutorial/venv.po
+++ b/tutorial/venv.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/tutorial/whatnow.po
+++ b/tutorial/whatnow.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/using/cmdline.po
+++ b/using/cmdline.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/using/index.po
+++ b/using/index.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/using/mac.po
+++ b/using/mac.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 msgid ""

--- a/using/unix.po
+++ b/using/unix.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/using/windows.po
+++ b/using/windows.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/whatsnew/2.0.po
+++ b/whatsnew/2.0.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/whatsnew/2.1.po
+++ b/whatsnew/2.1.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/whatsnew/2.2.po
+++ b/whatsnew/2.2.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/whatsnew/2.3.po
+++ b/whatsnew/2.3.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/whatsnew/2.4.po
+++ b/whatsnew/2.4.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/whatsnew/2.5.po
+++ b/whatsnew/2.5.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/whatsnew/2.6.po
+++ b/whatsnew/2.6.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/whatsnew/2.7.po
+++ b/whatsnew/2.7.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/whatsnew/3.0.po
+++ b/whatsnew/3.0.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/whatsnew/3.1.po
+++ b/whatsnew/3.1.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/whatsnew/3.2.po
+++ b/whatsnew/3.2.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/whatsnew/3.3.po
+++ b/whatsnew/3.3.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/whatsnew/3.4.po
+++ b/whatsnew/3.4.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/whatsnew/3.5.po
+++ b/whatsnew/3.5.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""

--- a/whatsnew/3.6.po
+++ b/whatsnew/3.6.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/whatsnew/3.7.po
+++ b/whatsnew/3.7.po
@@ -3,7 +3,7 @@
 # Maintained by the python-doc-es workteam.
 # docs-es@python.org /
 # https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
 #, fuzzy

--- a/whatsnew/index.po
+++ b/whatsnew/index.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Python package.
 # Maintained by the python-doc-es workteam. 
 # docs-es@python.org / https://mail.python.org/mailman3/lists/docs-es.python.org/
-# Check https://github.com/PyCampES/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
+# Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to get the list of volunteers
 #
 #, fuzzy
 msgid ""


### PR DESCRIPTION
Los links de la documentación apuntan actualmente a `github.com/PyCampES/python-docs-es`, requiriendo una redirección por parte del navegador a `github.com/python/python-docs-es`.

No sé si esto es necesario o deseado por alguna razón, si es así cierren este pull.

Closes #746 