### PR TITLE
Activación de entorno virtual en Makefile antes de ejecutar binarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ help:
 #        treated as errors, which is good to skip simple Sphinx syntax mistakes.
 .PHONY: build
 build: setup
-	PYTHONWARNINGS=ignore::FutureWarning $(VENV)/bin/sphinx-build -j auto -W --keep-going -b html -d $(OUTPUT_DOCTREE) -D language=$(LANGUAGE) . $(OUTPUT_HTML) && \
+	source $(VENV)/bin/activate && \
+		PYTHONWARNINGS=ignore::FutureWarning $(VENV)/bin/sphinx-build -j auto -W --keep-going -b html -d $(OUTPUT_DOCTREE) -D language=$(LANGUAGE) . $(OUTPUT_HTML) && \
 		echo "Success! Open file://`pwd`/$(OUTPUT_HTML)/index.html, " \
 			"or run 'make serve' to see them in http://localhost:8000";
 
@@ -64,7 +65,7 @@ venv:
 		$(PYTHON) -m venv --prompt $(LANGUAGE_TEAM) $(VENV);             \
 	fi
 
-	$(VENV)/bin/python -m pip install -q -r requirements.txt
+	source $(VENV)/bin/activate && $(VENV)/bin/python -m pip install -q -r requirements.txt
 
 
 # serve: serve the documentation in a simple local web server, using cpython
@@ -84,7 +85,7 @@ clean:
 
 .PHONY: progress
 progress: venv
-	$(VENV)/bin/potodo --offline --path tutorial/
+	source $(VENV)/bin/activate && $(VENV)/bin/potodo --offline --path tutorial/
 
 
 .PHONY: spell
@@ -92,12 +93,12 @@ spell: venv
 	# 'cat' tenia el problema que algunos archivos no tenían una nueva línea al final
 	# 'awk 1' agregará una nueva línea en caso que falte.
 	awk 1 dict dictionaries/*.txt > dict.txt
-	$(VENV)/bin/pospell -p dict.txt -l es_ES **/*.po
+	source $(VENV)/bin/activate && $(VENV)/bin/pospell -p dict.txt -l es_ES **/*.po
 
 
 .PHONY: wrap
 wrap: venv
-	$(VENV)/bin/powrap **/*.po
+	source $(VENV)/bin/activate && $(VENV)/bin/powrap **/*.po
 
 .PHONY: dict_dups
 SHELL:=/bin/bash


### PR DESCRIPTION
Closes #759

Actualmente el archivo `Makefile` está ejecutando binarios dentro del entorno virtual sin comprobar si se encuentra activado. Esto no es seguro y puede ocasionar que se importen bibliotecas globales de otras versiones a las instaladas dentro del entorno.

La solución pasa por activar el entorno antes de ejecutar binarios que se encuentran dentro del entorno. Nótese que el entorno no se mantiene activado cuando el comando finaliza, ya que `make` ejecuta los comandos en un nuevo proceso de consola.

Otra opción es obligar al usuario a activar el entorno virtual antes de ejecutar `make` y cerrar este pull, pero no me gusta obligar a los traductores a pensar como un programador, entiendo que no todo el mundo debe tener un conocimiento avanzado de Python para contribuir a este proyecto.