### PR TITLE
Traducido archivo asyncio-sync

### DIFF
--- a/dictionaries/library_asyncio_sync.txt
+++ b/dictionaries/library_asyncio_sync.txt
@@ -1,0 +1,4 @@
+BoundedSemaphore
+Condition
+Lock
+

--- a/library/asyncio-sync.po
+++ b/library/asyncio-sync.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: Python 3.8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-05-05 12:54+0200\n"
-"PO-Revision-Date: 2020-10-05 17:34+0200\n"
+"PO-Revision-Date: 2020-10-05 17:50+0200\n"
 "Language-Team: python-doc-es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -330,7 +330,7 @@ msgstr "Libera el cierre subyacente."
 #: ../Doc/library/asyncio-sync.rst:246
 msgid "When invoked on an unlocked lock, a :exc:`RuntimeError` is raised."
 msgstr ""
-"Cuando se invoca en un cierre cerrado, se lanza una execepción :exc:"
+"Cuando se invoca en un cierre cerrado, se lanza una excepción :exc:"
 "`RuntimeError`."
 
 #: ../Doc/library/asyncio-sync.rst:251

--- a/library/asyncio-sync.po
+++ b/library/asyncio-sync.po
@@ -28,7 +28,7 @@ msgstr "Primitivas de sincronización"
 
 #: ../Doc/library/asyncio-sync.rst:9
 msgid "**Source code:** :source:`Lib/asyncio/locks.py`"
-msgstr "**Source code:** :source:`Lib/asyncio/locks.py`"
+msgstr "**Código fuente:** :source:`Lib/asyncio/locks.py`"
 
 #: ../Doc/library/asyncio-sync.rst:13
 msgid ""
@@ -104,7 +104,7 @@ msgstr ""
 msgid "The preferred way to use a Lock is an :keyword:`async with` statement::"
 msgstr ""
 "La forma preferida de usar un Lock es mediante una declaración :keyword:"
-"`async with`:"
+"`async with`::"
 
 #: ../Doc/library/asyncio-sync.rst:55 ../Doc/library/asyncio-sync.rst:200
 #: ../Doc/library/asyncio-sync.rst:300
@@ -206,7 +206,7 @@ msgid ""
 "another task calls :meth:`set`."
 msgstr ""
 "Si el evento está establecido, retorna ``True`` inmediatamente. En caso "
-"contrario, bloquea hasta que alguna otra tarea llama al método :meth:`set`."
+"contrario, bloquea hasta que alguna otra tarea invoca al método :meth:`set`."
 
 #: ../Doc/library/asyncio-sync.rst:149
 msgid "Set the event."
@@ -455,7 +455,7 @@ msgid ""
 "counter above the initial *value*."
 msgstr ""
 "BoundedSemaphore es una versión de la clase :class:`Semaphore` que lanza una "
-"excepción :exc:`ValueError` en :meth:`~ Semaphore.release` si aumenta el "
+"excepción :exc:`ValueError` en :meth:`~Semaphore.release` si aumenta el "
 "contador interno por encima del *valor* inicial."
 
 #: ../Doc/library/asyncio-sync.rst:352
@@ -464,6 +464,6 @@ msgid ""
 "`with` statement (``with await lock``, ``with (yield from lock)``) is "
 "deprecated.  Use ``async with lock`` instead."
 msgstr ""
-"Adquirir un bloqueo usando ``await lock`` o ``yield from lock`` y / o la "
+"Adquirir un bloqueo usando ``await lock`` o ``yield from lock`` y/o la "
 "declaración :keyword:`with` (``with await lock``, ``with (yield from "
 "lock)``) está obsoleto. En su lugar, se debe usar ``async with lock``."

--- a/library/asyncio-sync.po
+++ b/library/asyncio-sync.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: Python 3.8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-05-05 12:54+0200\n"
-"PO-Revision-Date: 2020-10-05 17:50+0200\n"
+"PO-Revision-Date: 2020-10-05 19:15+0200\n"
 "Language-Team: python-doc-es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -157,7 +157,7 @@ msgstr ""
 #: ../Doc/library/asyncio-sync.rst:89
 msgid "If the lock is *unlocked*, a :exc:`RuntimeError` is raised."
 msgstr ""
-"Si el cierre está *cerrado*, se lanza una excepción :exc:`RuntimeError`."
+"Si el cierre está *abierto*, se lanza una excepción :exc:`RuntimeError`."
 
 #: ../Doc/library/asyncio-sync.rst:93
 msgid "Return ``True`` if the lock is *locked*."
@@ -330,7 +330,7 @@ msgstr "Libera el cierre subyacente."
 #: ../Doc/library/asyncio-sync.rst:246
 msgid "When invoked on an unlocked lock, a :exc:`RuntimeError` is raised."
 msgstr ""
-"Cuando se invoca en un cierre cerrado, se lanza una excepción :exc:"
+"Cuando se invoca en un cierre abierto, se lanza una excepción :exc:"
 "`RuntimeError`."
 
 #: ../Doc/library/asyncio-sync.rst:251

--- a/library/asyncio-sync.po
+++ b/library/asyncio-sync.po
@@ -6,39 +6,47 @@
 # Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Python 3.8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-05-05 12:54+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"PO-Revision-Date: 2020-10-05 17:34+0200\n"
 "Language-Team: python-doc-es\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Last-Translator: Francisco Jesús Sevilla García <fjsevilla.dev@gmail.com>\n"
+"Language: es\n"
+"X-Generator: Poedit 2.4.1\n"
 
 #: ../Doc/library/asyncio-sync.rst:7
 msgid "Synchronization Primitives"
-msgstr ""
+msgstr "Primitivas de sincronización"
 
 #: ../Doc/library/asyncio-sync.rst:9
 msgid "**Source code:** :source:`Lib/asyncio/locks.py`"
-msgstr ""
+msgstr "**Source code:** :source:`Lib/asyncio/locks.py`"
 
 #: ../Doc/library/asyncio-sync.rst:13
 msgid ""
 "asyncio synchronization primitives are designed to be similar to those of "
 "the :mod:`threading` module with two important caveats:"
 msgstr ""
+"Las primitivas de sincronización de asyncio están diseñadas para ser "
+"similares a las del módulo :mod:`threading`, con dos importantes "
+"advertencias:"
 
 #: ../Doc/library/asyncio-sync.rst:16
 msgid ""
 "asyncio primitives are not thread-safe, therefore they should not be used "
 "for OS thread synchronization (use :mod:`threading` for that);"
 msgstr ""
+"las primitivas de asyncio no son seguras en hilos, por lo tanto, no deben "
+"ser usadas para la sincronización de hilos del sistema operativo (usa :mod:"
+"`threading` para esto);"
 
 #: ../Doc/library/asyncio-sync.rst:20
 msgid ""
@@ -46,111 +54,130 @@ msgid ""
 "argument; use the :func:`asyncio.wait_for` function to perform operations "
 "with timeouts."
 msgstr ""
+"los métodos de estas primitivas de sincronización no aceptan el argumento "
+"*timeout*. Usa la función :func:`asyncio.wait_for` para realizar operaciones "
+"que involucren tiempos de espera."
 
 #: ../Doc/library/asyncio-sync.rst:24
 msgid "asyncio has the following basic synchronization primitives:"
-msgstr ""
+msgstr "asyncio tiene las siguientes primitivas de sincronización básicas:"
 
 #: ../Doc/library/asyncio-sync.rst:26
 msgid ":class:`Lock`"
-msgstr ""
+msgstr ":class:`Lock`"
 
 #: ../Doc/library/asyncio-sync.rst:27
 msgid ":class:`Event`"
-msgstr ""
+msgstr ":class:`Event`"
 
 #: ../Doc/library/asyncio-sync.rst:28
 msgid ":class:`Condition`"
-msgstr ""
+msgstr ":class:`Condition`"
 
 #: ../Doc/library/asyncio-sync.rst:29
 msgid ":class:`Semaphore`"
-msgstr ""
+msgstr ":class:`Semaphore`"
 
 #: ../Doc/library/asyncio-sync.rst:30
 msgid ":class:`BoundedSemaphore`"
-msgstr ""
+msgstr ":class:`BoundedSemaphore`"
 
 #: ../Doc/library/asyncio-sync.rst:37
 msgid "Lock"
-msgstr ""
+msgstr "Lock"
 
 #: ../Doc/library/asyncio-sync.rst:41
 msgid "Implements a mutex lock for asyncio tasks.  Not thread-safe."
 msgstr ""
+"Implementa un cierre de exclusión mutua para tareas asyncio. No es seguro en "
+"hilos."
 
 #: ../Doc/library/asyncio-sync.rst:43
 msgid ""
 "An asyncio lock can be used to guarantee exclusive access to a shared "
 "resource."
 msgstr ""
+"Un cierre asyncio puede usarse para garantizar el acceso en exclusiva a un "
+"recurso compartido."
 
 #: ../Doc/library/asyncio-sync.rst:46
 msgid "The preferred way to use a Lock is an :keyword:`async with` statement::"
 msgstr ""
+"La forma preferida de usar un Lock es mediante una declaración :keyword:"
+"`async with`:"
 
 #: ../Doc/library/asyncio-sync.rst:55 ../Doc/library/asyncio-sync.rst:200
 #: ../Doc/library/asyncio-sync.rst:300
 msgid "which is equivalent to::"
-msgstr ""
+msgstr "lo que es equivalente a:"
 
 #: ../Doc/library/asyncio-sync.rst:68 ../Doc/library/asyncio-sync.rst:114
 #: ../Doc/library/asyncio-sync.rst:190 ../Doc/library/asyncio-sync.rst:290
 #: ../Doc/library/asyncio-sync.rst:345
 msgid "The *loop* parameter."
-msgstr ""
+msgstr "El parámetro *loop*."
 
 #: ../Doc/library/asyncio-sync.rst:71
 msgid "Acquire the lock."
-msgstr ""
+msgstr "Adquiere el cierre."
 
 #: ../Doc/library/asyncio-sync.rst:73
 msgid ""
 "This method waits until the lock is *unlocked*, sets it to *locked* and "
 "returns ``True``."
 msgstr ""
+"Este método espera hasta que el cierre está *abierto*, lo establece como "
+"*cerrado* y retorna ``True``."
 
 #: ../Doc/library/asyncio-sync.rst:76
 msgid ""
 "When more than one coroutine is blocked in :meth:`acquire` waiting for the "
 "lock to be unlocked, only one coroutine eventually proceeds."
 msgstr ""
+"Cuando más de una corrutina está bloqueada en :meth:`acquire`, esperando a "
+"que el cierre se abra, solo una de las corrutinas proseguirá finalmente."
 
 #: ../Doc/library/asyncio-sync.rst:80
 msgid ""
 "Acquiring a lock is *fair*: the coroutine that proceeds will be the first "
 "coroutine that started waiting on the lock."
 msgstr ""
+"Adquirir un cierre es *justo*: la corrutina que prosigue será la primera "
+"corrutina que comenzó a esperarlo."
 
 #: ../Doc/library/asyncio-sync.rst:85
 msgid "Release the lock."
-msgstr ""
+msgstr "Libera el cierre."
 
 #: ../Doc/library/asyncio-sync.rst:87
 msgid "When the lock is *locked*, reset it to *unlocked* and return."
 msgstr ""
+"Cuando el cierre está *cerrado*, lo restablece al estado *abierto* y retorna."
 
 #: ../Doc/library/asyncio-sync.rst:89
 msgid "If the lock is *unlocked*, a :exc:`RuntimeError` is raised."
 msgstr ""
+"Si el cierre está *cerrado*, se lanza una excepción :exc:`RuntimeError`."
 
 #: ../Doc/library/asyncio-sync.rst:93
 msgid "Return ``True`` if the lock is *locked*."
-msgstr ""
+msgstr "Retorna ``True`` si el cierre está *cerrado*."
 
 #: ../Doc/library/asyncio-sync.rst:97
 msgid "Event"
-msgstr ""
+msgstr "Event"
 
 #: ../Doc/library/asyncio-sync.rst:101
 msgid "An event object.  Not thread-safe."
-msgstr ""
+msgstr "Un objeto de eventos. No es seguro en hilos."
 
 #: ../Doc/library/asyncio-sync.rst:103
 msgid ""
 "An asyncio event can be used to notify multiple asyncio tasks that some "
 "event has happened."
 msgstr ""
+"Un evento asyncio puede usarse para notificar a múltiples tareas asyncio que "
+"ha ocurrido algún evento."
 
 #: ../Doc/library/asyncio-sync.rst:106
 msgid ""
@@ -159,56 +186,69 @@ msgid ""
 "meth:`wait` method blocks until the flag is set to *true*.  The flag is set "
 "to *false* initially."
 msgstr ""
+"Un objeto Event gestiona un indicador interno que puede ser establecido en "
+"*verdadero* mediante el método :meth:`set` y restaurado a *falso* con el "
+"método :meth:`clear`. El método :meth:`wait` bloquea hasta que el indicador "
+"es establecido en *verdadero*. De inicio, el indicador se establece en "
+"*falso*."
 
 #: ../Doc/library/asyncio-sync.rst:117
 msgid "Example::"
-msgstr ""
+msgstr "Ejemplo:"
 
 #: ../Doc/library/asyncio-sync.rst:142
 msgid "Wait until the event is set."
-msgstr ""
+msgstr "Espera hasta que el evento se estable."
 
 #: ../Doc/library/asyncio-sync.rst:144
 msgid ""
 "If the event is set, return ``True`` immediately. Otherwise block until "
 "another task calls :meth:`set`."
 msgstr ""
+"Si el evento está establecido, retorna ``True`` inmediatamente. En caso "
+"contrario, bloquea hasta que alguna otra tarea llama al método :meth:`set`."
 
 #: ../Doc/library/asyncio-sync.rst:149
 msgid "Set the event."
-msgstr ""
+msgstr "Establece el evento."
 
 #: ../Doc/library/asyncio-sync.rst:151
 msgid "All tasks waiting for event to be set will be immediately awakened."
 msgstr ""
+"Todas las tareas esperando a que el evento se establezca serán activadas "
+"inmediatamente."
 
 #: ../Doc/library/asyncio-sync.rst:156
 msgid "Clear (unset) the event."
-msgstr ""
+msgstr "Borra (restablece) el evento."
 
 #: ../Doc/library/asyncio-sync.rst:158
 msgid ""
 "Tasks awaiting on :meth:`wait` will now block until the :meth:`set` method "
 "is called again."
 msgstr ""
+"Las tareas pendientes en :meth:`wait` ahora se bloquearán hasta que se "
+"vuelva a llamar al método :meth:`set` de nuevo."
 
 #: ../Doc/library/asyncio-sync.rst:163
 msgid "Return ``True`` if the event is set."
-msgstr ""
+msgstr "Retorna ``True`` si el evento está establecido."
 
 #: ../Doc/library/asyncio-sync.rst:167
 msgid "Condition"
-msgstr ""
+msgstr "Condition"
 
 #: ../Doc/library/asyncio-sync.rst:171
 msgid "A Condition object.  Not thread-safe."
-msgstr ""
+msgstr "Un objeto Condition. No seguro en hilos."
 
 #: ../Doc/library/asyncio-sync.rst:173
 msgid ""
 "An asyncio condition primitive can be used by a task to wait for some event "
 "to happen and then get exclusive access to a shared resource."
 msgstr ""
+"Una tarea puede usar una condición primitiva de asyncio para esperar a que "
+"suceda algún evento y luego obtener acceso exclusivo a un recurso compartido."
 
 #: ../Doc/library/asyncio-sync.rst:177
 msgid ""
@@ -218,33 +258,46 @@ msgid ""
 "shared resource between different tasks interested in particular states of "
 "that shared resource."
 msgstr ""
+"En esencia, un objeto Condition combina la funcionalidad de un objeto :class:"
+"`Event` y un objeto :class:`Lock`. Es posible tener múltiples objetos "
+"Condition que compartan un mismo Lock, lo que permite coordinar el acceso "
+"exclusivo a un recurso compartido entre diferentes tareas interesadas en "
+"estados particulares de ese recurso compartido."
 
 #: ../Doc/library/asyncio-sync.rst:183
 msgid ""
 "The optional *lock* argument must be a :class:`Lock` object or ``None``.  In "
 "the latter case a new Lock object is created automatically."
 msgstr ""
+"El argumento opcional *lock* debe ser un objeto :class:`Lock` o ``None``. En "
+"este último caso, se crea automáticamente un nuevo objeto Lock."
 
 #: ../Doc/library/asyncio-sync.rst:191
 msgid ""
 "The preferred way to use a Condition is an :keyword:`async with` statement::"
 msgstr ""
+"La forma preferida de usar una condición es mediante una declaración :"
+"keyword:`async with`:"
 
 #: ../Doc/library/asyncio-sync.rst:213
 msgid "Acquire the underlying lock."
-msgstr ""
+msgstr "Adquiere el cierre (lock) subyacente."
 
 #: ../Doc/library/asyncio-sync.rst:215
 msgid ""
 "This method waits until the underlying lock is *unlocked*, sets it to "
 "*locked* and returns ``True``."
 msgstr ""
+"Este método espera hasta que el cierre subyacente esté *abierto*, lo "
+"establece en *cerrado* y retorna ``True``."
 
 #: ../Doc/library/asyncio-sync.rst:220
 msgid ""
 "Wake up at most *n* tasks (1 by default) waiting on this condition.  The "
 "method is no-op if no tasks are waiting."
 msgstr ""
+"Despierta como máximo *n* tareas (1 por defecto) que estén esperando a esta "
+"condición. El método no es operativo si no hay tareas esperando."
 
 #: ../Doc/library/asyncio-sync.rst:223 ../Doc/library/asyncio-sync.rst:238
 msgid ""
@@ -252,36 +305,45 @@ msgid ""
 "after.  If called with an *unlocked* lock a :exc:`RuntimeError` error is "
 "raised."
 msgstr ""
+"El cierre debe adquirirse antes de llamar a este método y liberarse poco "
+"después. Si se llama con un cierre *abierto*, se lanza una excepción :exc:"
+"`RuntimeError`."
 
 #: ../Doc/library/asyncio-sync.rst:229
 msgid "Return ``True`` if the underlying lock is acquired."
-msgstr ""
+msgstr "Retorna ``True`` si el cierre subyacente está adquirido."
 
 #: ../Doc/library/asyncio-sync.rst:233
 msgid "Wake up all tasks waiting on this condition."
-msgstr ""
+msgstr "Despierta todas las tareas que esperan a esta condición."
 
 #: ../Doc/library/asyncio-sync.rst:235
 msgid "This method acts like :meth:`notify`, but wakes up all waiting tasks."
 msgstr ""
+"Este método actúa como :meth:`notify`, pero despierta todas las tareas en "
+"espera."
 
 #: ../Doc/library/asyncio-sync.rst:244
 msgid "Release the underlying lock."
-msgstr ""
+msgstr "Libera el cierre subyacente."
 
 #: ../Doc/library/asyncio-sync.rst:246
 msgid "When invoked on an unlocked lock, a :exc:`RuntimeError` is raised."
 msgstr ""
+"Cuando se invoca en un cierre cerrado, se lanza una execepción :exc:"
+"`RuntimeError`."
 
 #: ../Doc/library/asyncio-sync.rst:251
 msgid "Wait until notified."
-msgstr ""
+msgstr "Espera hasta que se le notifique."
 
 #: ../Doc/library/asyncio-sync.rst:253
 msgid ""
 "If the calling task has not acquired the lock when this method is called, a :"
 "exc:`RuntimeError` is raised."
 msgstr ""
+"Si la tarea que llama no ha adquirido el cierre cuando se llama a este "
+"método, se lanza una excepción :exc:`RuntimeError`."
 
 #: ../Doc/library/asyncio-sync.rst:256
 msgid ""
@@ -289,24 +351,30 @@ msgid ""
 "awakened by a :meth:`notify` or :meth:`notify_all` call. Once awakened, the "
 "Condition re-acquires its lock and this method returns ``True``."
 msgstr ""
+"Este método libera el cierre subyacente y luego se bloquea hasta que lo "
+"despierte una llamada :meth:`notify` o :meth:`notify_all`. Una vez "
+"despertado, la condición vuelve a adquirir su cierre y este método "
+"retorna``True``."
 
 #: ../Doc/library/asyncio-sync.rst:263
 msgid "Wait until a predicate becomes *true*."
-msgstr ""
+msgstr "Espera hasta que un predicado se vuelva *verdadero*."
 
 #: ../Doc/library/asyncio-sync.rst:265
 msgid ""
 "The predicate must be a callable which result will be interpreted as a "
 "boolean value.  The final value is the return value."
 msgstr ""
+"El predicado debe ser un objeto invocable cuyo resultado se interpretará "
+"como un valor booleano. El valor final es el valor de retorno."
 
 #: ../Doc/library/asyncio-sync.rst:271
 msgid "Semaphore"
-msgstr ""
+msgstr "Semaphore"
 
 #: ../Doc/library/asyncio-sync.rst:275
 msgid "A Semaphore object.  Not thread-safe."
-msgstr ""
+msgstr "Un objeto Semaphore. No es seguro en hilos."
 
 #: ../Doc/library/asyncio-sync.rst:277
 msgid ""
@@ -315,6 +383,11 @@ msgid ""
 "never go below zero; when :meth:`acquire` finds that it is zero, it blocks, "
 "waiting until some task calls :meth:`release`."
 msgstr ""
+"Un semáforo gestiona un contador interno que se reduce en cada llamada al "
+"método :meth:`acquire` y se incrementa en cada llamada al método :meth:"
+"`release`. El contador nunca puede bajar de cero, cuando :meth:`acquire` "
+"encuentra que es cero, se bloquea, esperando hasta que alguna tarea llame a :"
+"meth:`release`."
 
 #: ../Doc/library/asyncio-sync.rst:283
 msgid ""
@@ -322,15 +395,20 @@ msgid ""
 "counter (``1`` by default). If the given value is less than ``0`` a :exc:"
 "`ValueError` is raised."
 msgstr ""
+"El argumento opcional *value* proporciona el valor inicial para el contador "
+"interno (``1`` por defecto). Si el valor dado es menor que ``0`` se lanza "
+"una excepción :exc:`ValueError`."
 
 #: ../Doc/library/asyncio-sync.rst:291
 msgid ""
 "The preferred way to use a Semaphore is an :keyword:`async with` statement::"
 msgstr ""
+"La forma preferida de utilizar un semáforo es mediante una declaración :"
+"keyword:`async with`:"
 
 #: ../Doc/library/asyncio-sync.rst:313
 msgid "Acquire a semaphore."
-msgstr ""
+msgstr "Adquiere un semáforo."
 
 #: ../Doc/library/asyncio-sync.rst:315
 msgid ""
@@ -338,30 +416,37 @@ msgid ""
 "``True`` immediately.  If it is zero, wait until a :meth:`release` is called "
 "and return ``True``."
 msgstr ""
+"Si el contador interno es mayor que cero, lo reduce en uno y retorna "
+"``True`` inmediatamente. Si es cero, espera hasta que se llame al método :"
+"meth:`release` y retorna ``True``."
 
 #: ../Doc/library/asyncio-sync.rst:321
 msgid "Returns ``True`` if semaphore can not be acquired immediately."
-msgstr ""
+msgstr "Retorna ``True`` si el semáforo no se puede adquirir de inmediato."
 
 #: ../Doc/library/asyncio-sync.rst:325
 msgid ""
 "Release a semaphore, incrementing the internal counter by one. Can wake up a "
 "task waiting to acquire the semaphore."
 msgstr ""
+"Libera un semáforo, incrementando el contador interno en uno. Puede "
+"despertar una tarea que esté a la espera para adquirir el semáforo."
 
 #: ../Doc/library/asyncio-sync.rst:328
 msgid ""
 "Unlike :class:`BoundedSemaphore`, :class:`Semaphore` allows making more "
 "``release()`` calls than ``acquire()`` calls."
 msgstr ""
+"A diferencia de :class:`BoundedSemaphore`, :class:`Semaphore` permite hacer "
+"más llamadas ``release()`` que llamadas ``acquire()``."
 
 #: ../Doc/library/asyncio-sync.rst:333
 msgid "BoundedSemaphore"
-msgstr ""
+msgstr "BoundedSemaphore"
 
 #: ../Doc/library/asyncio-sync.rst:337
 msgid "A bounded semaphore object.  Not thread-safe."
-msgstr ""
+msgstr "Un objeto semáforo delimitado. No es seguro en hilos."
 
 #: ../Doc/library/asyncio-sync.rst:339
 msgid ""
@@ -369,6 +454,9 @@ msgid ""
 "`ValueError` in :meth:`~Semaphore.release` if it increases the internal "
 "counter above the initial *value*."
 msgstr ""
+"BoundedSemaphore es una versión de la clase :class:`Semaphore` que lanza una "
+"excepción :exc:`ValueError` en :meth:`~ Semaphore.release` si aumenta el "
+"contador interno por encima del *valor* inicial."
 
 #: ../Doc/library/asyncio-sync.rst:352
 msgid ""
@@ -376,3 +464,6 @@ msgid ""
 "`with` statement (``with await lock``, ``with (yield from lock)``) is "
 "deprecated.  Use ``async with lock`` instead."
 msgstr ""
+"Adquirir un bloqueo usando ``await lock`` o ``yield from lock`` y / o la "
+"declaración :keyword:`with` (``with await lock``, ``with (yield from "
+"lock)``) está obsoleto. En su lugar, se debe usar ``async with lock``."

--- a/library/asyncio-sync.po
+++ b/library/asyncio-sync.po
@@ -109,7 +109,7 @@ msgstr ""
 #: ../Doc/library/asyncio-sync.rst:55 ../Doc/library/asyncio-sync.rst:200
 #: ../Doc/library/asyncio-sync.rst:300
 msgid "which is equivalent to::"
-msgstr "lo que es equivalente a:"
+msgstr "lo que es equivalente a::"
 
 #: ../Doc/library/asyncio-sync.rst:68 ../Doc/library/asyncio-sync.rst:114
 #: ../Doc/library/asyncio-sync.rst:190 ../Doc/library/asyncio-sync.rst:290
@@ -198,7 +198,7 @@ msgstr "Ejemplo:"
 
 #: ../Doc/library/asyncio-sync.rst:142
 msgid "Wait until the event is set."
-msgstr "Espera hasta que el evento se estable."
+msgstr "Espera hasta que se establezca el evento."
 
 #: ../Doc/library/asyncio-sync.rst:144
 msgid ""
@@ -277,7 +277,7 @@ msgid ""
 "The preferred way to use a Condition is an :keyword:`async with` statement::"
 msgstr ""
 "La forma preferida de usar una condición es mediante una declaración :"
-"keyword:`async with`:"
+"keyword:`async with`::"
 
 #: ../Doc/library/asyncio-sync.rst:213
 msgid "Acquire the underlying lock."
@@ -404,7 +404,7 @@ msgid ""
 "The preferred way to use a Semaphore is an :keyword:`async with` statement::"
 msgstr ""
 "La forma preferida de utilizar un semáforo es mediante una declaración :"
-"keyword:`async with`:"
+"keyword:`async with`::"
 
 #: ../Doc/library/asyncio-sync.rst:313
 msgid "Acquire a semaphore."


### PR DESCRIPTION
Closes #800

### Nota para revisor@s

He usado "cierre" para "lock" porque es la traducción que se usa en la[ entrada correspondiente de Wikipedia](https://es.wikipedia.org/wiki/Cierre_de_exclusi%C3%B3n_mutua). Realmente no tengo una posición fuerte al respecto, entre usar "cierre" u otras traducciones que he visto alguna vez para el término ("candado", "cerrojo" y "bloqueo" principalmente). 