### PR TITLE
pequeño comentario en el paso a paso

### DIFF
--- a/.overrides/CONTRIBUTING.rst
+++ b/.overrides/CONTRIBUTING.rst
@@ -64,7 +64,9 @@ Antes de comenzar
 
 #. Selecciona un :ref:`archivo para traducir <que-archivo-traducir>`.
 
-#. Verifica que estás en la rama principal del repositorio, **3.8**::
+#. Verifica que estás en la rama principal del repositorio, **3.8** (esto es muy 
+   importante para evitar crear una nueva rama a partir de una traducción 
+   anterior)::
 
      git checkout 3.8
 


### PR DESCRIPTION
Al parecer es un error común crear una nueva branch dentro de la branch de una traducción anterior. No se me ocurre otro lugar dónde incluir la aclaración.