### PR TITLE
Completada traducción de library/time

### DIFF
--- a/library/time.po
+++ b/library/time.po
@@ -11,15 +11,15 @@ msgstr ""
 "Project-Id-Version: Python 3.8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-05-05 12:54+0200\n"
-"PO-Revision-Date: 2020-06-22 21:24-0600\n"
+"PO-Revision-Date: 2020-10-09 20:15+0200\n"
 "Language-Team: python-doc-es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
-"Last-Translator: \n"
+"Last-Translator: Álvaro Mondéjar <mondejar1994@gmail.com>\n"
 "Language: es\n"
-"X-Generator: Poedit 2.3.1\n"
+"X-Generator: Poedit 2.4.1\n"
 
 #: ../Doc/library/time.rst:2
 msgid ":mod:`time` --- Time access and conversions"
@@ -547,6 +547,13 @@ msgid ""
 "requested by an arbitrary amount because of the scheduling of other activity "
 "in the system."
 msgstr ""
+"Suspende la ejecución del hilo que lo invoca por el número de segundos dado. "
+"El argumento puede ser un número de punto flotante para indicar un tiempo de "
+"suspensión más preciso. El tiempo de suspensión real puede ser menor que el "
+"solicitado porque cualquier señal detectada terminará la función :func:"
+"`sleep` siguiendo la rutina de captura de la señal. El tiempo de suspensión "
+"también puede ser más largo que el solicitado por una cantidad arbitraria "
+"debido a la programación de otra actividad en el sistema."
 
 #: ../Doc/library/time.rst:338
 msgid ""
@@ -992,7 +999,7 @@ msgstr ":attr:`tm_mon`"
 
 #: ../Doc/library/time.rst:526
 msgid "range [1, 12]"
-msgstr "range [1, 12]"
+msgstr "rango [1, 12]"
 
 #: ../Doc/library/time.rst:528
 msgid "2"
@@ -1004,7 +1011,7 @@ msgstr ":attr:`tm_mday`"
 
 #: ../Doc/library/time.rst:528
 msgid "range [1, 31]"
-msgstr "range [1, 31]"
+msgstr "rango [1, 31]"
 
 #: ../Doc/library/time.rst:530
 msgid "3"
@@ -1016,75 +1023,75 @@ msgstr ":attr:`tm_hour`"
 
 #: ../Doc/library/time.rst:530
 msgid "range [0, 23]"
-msgstr ""
+msgstr "rango [0, 23]"
 
 #: ../Doc/library/time.rst:532
 msgid "4"
-msgstr ""
+msgstr "4"
 
 #: ../Doc/library/time.rst:532
 msgid ":attr:`tm_min`"
-msgstr ""
+msgstr ":attr:`tm_min`"
 
 #: ../Doc/library/time.rst:532
 msgid "range [0, 59]"
-msgstr ""
+msgstr "rango [0, 59]"
 
 #: ../Doc/library/time.rst:534
 msgid "5"
-msgstr ""
+msgstr "5"
 
 #: ../Doc/library/time.rst:534
 msgid ":attr:`tm_sec`"
-msgstr ""
+msgstr ":attr:`tm_sec`"
 
 #: ../Doc/library/time.rst:534
 msgid "range [0, 61]; see **(2)** in :func:`strftime` description"
-msgstr "range [0, 61]; ver **(2)** in :func:`strftime` descripción"
+msgstr "rango [0, 61]; ver **(2)** in :func:`strftime` descripción"
 
 #: ../Doc/library/time.rst:537
 msgid "6"
-msgstr ""
+msgstr "6"
 
 #: ../Doc/library/time.rst:537
 msgid ":attr:`tm_wday`"
-msgstr ""
+msgstr ":attr:`tm_wday`"
 
 #: ../Doc/library/time.rst:537
 msgid "range [0, 6], Monday is 0"
-msgstr "range [0, 6], Lunes es 0"
+msgstr "rango [0, 6], Lunes es 0"
 
 #: ../Doc/library/time.rst:539
 msgid "7"
-msgstr ""
+msgstr "7"
 
 #: ../Doc/library/time.rst:539
 msgid ":attr:`tm_yday`"
-msgstr ""
+msgstr ":attr:`tm_yday`"
 
 #: ../Doc/library/time.rst:539
 msgid "range [1, 366]"
-msgstr ""
+msgstr "rango [1, 366]"
 
 #: ../Doc/library/time.rst:541
 msgid "8"
-msgstr ""
+msgstr "8"
 
 #: ../Doc/library/time.rst:541
 msgid ":attr:`tm_isdst`"
-msgstr ""
+msgstr ":attr:`tm_isdst`"
 
 #: ../Doc/library/time.rst:541
 msgid "0, 1 or -1; see below"
-msgstr ""
+msgstr "0, 1 ó -1; ver abajo"
 
 #: ../Doc/library/time.rst:543 ../Doc/library/time.rst:545
 msgid "N/A"
-msgstr ""
+msgstr "N/A"
 
 #: ../Doc/library/time.rst:543
 msgid ":attr:`tm_zone`"
-msgstr ""
+msgstr ":attr:`tm_zone`"
 
 #: ../Doc/library/time.rst:543
 msgid "abbreviation of timezone name"
@@ -1092,11 +1099,11 @@ msgstr "abreviatura del nombre de la zona horaria"
 
 #: ../Doc/library/time.rst:545
 msgid ":attr:`tm_gmtoff`"
-msgstr ""
+msgstr ":attr:`tm_gmtoff`"
 
 #: ../Doc/library/time.rst:545
 msgid "offset east of UTC in seconds"
-msgstr ""
+msgstr "desplazamiento al este de UTC en segundos"
 
 #: ../Doc/library/time.rst:548
 msgid ""
@@ -1299,7 +1306,7 @@ msgstr ""
 
 #: ../Doc/library/time.rst:661
 msgid ":samp:`J{n}`"
-msgstr ""
+msgstr ":samp:`J{n}`"
 
 #: ../Doc/library/time.rst:660
 msgid ""
@@ -1312,7 +1319,7 @@ msgstr ""
 
 #: ../Doc/library/time.rst:665
 msgid ":samp:`{n}`"
-msgstr ""
+msgstr ":samp:`{n}`"
 
 #: ../Doc/library/time.rst:664
 msgid ""
@@ -1324,7 +1331,7 @@ msgstr ""
 
 #: ../Doc/library/time.rst:672
 msgid ":samp:`M{m}.{n}.{d}`"
-msgstr ""
+msgstr ":samp:`M{m}.{n}.{d}`"
 
 #: ../Doc/library/time.rst:668
 msgid ""


### PR DESCRIPTION
Closes #1022

He cambiado algunas traducciones anteriores que especificaban `range <lista>`, porque en ese contexto no se refiere a un rango con la función `range()`, si no a un rango de números, por lo que la palabra `range` en ese contexto debe ser traducida. Se puede ver el resultado actual sin el cambio en la tabla de la función [`time.struct_time`](https://docs.python.org/es/3.8/library/time.html#time.struct_time) para entender a lo que me refiero.