### PR TITLE
Agregar script para crear dict.txt

### DIFF
--- a/.overrides/faq.rst
+++ b/.overrides/faq.rst
@@ -26,8 +26,8 @@ pospell. Pospell puede ser instalada en tu entorno de Python empleando pip
 Una vez instalado, para chequear el fichero .po sobre el que estás trabajando,
 ejecuta desde el directorio principal del repo::
 
-    awk 1 dict dictionaries/*.txt > dict.txt
-    pospell -p dict.txt -l es_AR -l es_ES path/tu_fichero.po
+    python scripts/create_dict.py  # para crear el archivo 'dict.txt'
+    pospell -p dict.txt -l es_ES path/tu_fichero.po
 
 pospell emplea la herramienta de diccionarios hunspell. Si pospell falla dando
 como error que no tiene hunspell instalado, lo puedes instalar así:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,8 @@ repos:
     hooks:
     -   id: merge-dicts
         name: merge-dicts
-        entry: ./scripts/merge-dicts.sh
-        language: script
+        entry: python ./scripts/create_dict.py
+        language: python
 # This one requires package ``hunspell-es_es`` in Archlinux
 -   repo: https://github.com/JulienPalard/pospell
     rev: v1.0.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - powrap --version
 script:
   - powrap --check --quiet **/*.po
-  - awk 1 dict dictionaries/*.txt > dict.txt
+  - python scripts/create_dict.py
   - pospell -p dict.txt -l es_AR -l es_ES **/*.po
   - pip install -q -r requirements.txt
   - PYTHONWARNINGS=ignore::FutureWarning sphinx-build -j auto -W --keep-going -b html -d cpython/Doc/_build/doctree -D language=es . cpython/Doc/_build/html

--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,7 @@ progress: venv
 
 .PHONY: spell
 spell: venv
-	# 'cat' tenia el problema que algunos archivos no tenían una nueva línea al final
-	# 'awk 1' agregará una nueva línea en caso que falte.
-	awk 1 dict dictionaries/*.txt > dict.txt
+	$(VENV)/bin/python scripts/create_dict.py
 	$(VENV)/bin/pospell -p dict.txt -l es_ES **/*.po
 
 

--- a/scripts/create_dict.py
+++ b/scripts/create_dict.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+"""
+Script to generate the 'dict.txt' dictionary based
+on the custom dictionaries under the 'dictionaries/' directory,
+but also considering the old words from the 'dict' file.
+
+This was done with:
+    awk 1 dict dictionaries/*.txt > dict.txt
+but the problem was that windows users, not using Git bash
+have the problem that 'awk' is not a valid command, so this
+enable them to use the script instead.
+"""
+
+entries = set()
+
+# Read custom dictionaries
+for name in os.listdir("dictionaries"):
+    if name.endswith(".txt"):
+        filename = os.path.join("dictionaries", name)
+        with open(filename, "r") as f:
+            lines = [i.rstrip() for i in f.readlines()]
+            if lines:
+                entries.update(set(lines))
+                del lines
+
+# Remove empty string, from empty lines
+entries.remove("")
+
+# Read main 'dict'
+with open("dict", "r") as f:
+    entries.update(set(i.rstrip() for i in f.readlines()))
+
+# Write the 'dict.txt' file
+with open("dict.txt", "w") as f:
+    for e in entries:
+        f.write(e)
+        f.write("\n")
+print("Created 'dict.txt'")

--- a/scripts/create_dict.py
+++ b/scripts/create_dict.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import sys
 
@@ -16,14 +17,12 @@ enable them to use the script instead.
 entries = set()
 
 # Read custom dictionaries
-for name in os.listdir("dictionaries"):
-    if name.endswith(".txt"):
-        filename = os.path.join("dictionaries", name)
-        with open(filename, "r") as f:
-            lines = [i.rstrip() for i in f.readlines()]
-            if lines:
-                entries.update(set(lines))
-                del lines
+for filename in glob.glob(os.path.join("dictionaries", "*.txt")):
+    with open(filename, "r") as f:
+        lines = [i.rstrip() for i in f.readlines()]
+    if lines:
+        entries.update(set(lines))
+        del lines
 
 # Remove empty string, from empty lines
 entries.remove("")

--- a/scripts/create_dict.py
+++ b/scripts/create_dict.py
@@ -1,6 +1,4 @@
-import glob
-import os
-import sys
+from pathlib import Path
 
 """
 Script to generate the 'dict.txt' dictionary based
@@ -17,7 +15,7 @@ enable them to use the script instead.
 entries = set()
 
 # Read custom dictionaries
-for filename in glob.glob(os.path.join("dictionaries", "*.txt")):
+for filename in Path("dictionaries").glob("*.txt"):
     with open(filename, "r") as f:
         lines = [i.rstrip() for i in f.readlines()]
     if lines:

--- a/scripts/merge-dicts.sh
+++ b/scripts/merge-dicts.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-awk 1 dict dictionaries/*.txt > dict.txt


### PR DESCRIPTION
Usuarios en Windows, que no utilizan Git bash no pueden generar el
archivo `dict.txt`, pues no tienen acceso al comando 'awk'.
Si bien, la construcción de toda la documentación no es necesaria,
este paso es importante incluso cuando se quiere hacer la verificación
pospell a un archivo determinado, pues necesitamos el diccionario
general que incluye todas las variaciones de 'dictionaries/'
y 'dict'.