### PR TITLE
Congelada versión de pospell a 1.0.5 en requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pip==20.1
 Sphinx==2.2.0
 blurb
 polib
-pospell>=1.0.4
+pospell==1.0.5
 potodo
 powrap
 python-docs-theme


### PR DESCRIPTION
Las construcciones están fallando en TravisCI porque ha sido lanzada una nueva versión de pospell (1.0.6) que descubre más fallos en los archivos po y está siendo instalada en el flujo de trabajo de testeo.