### PR TITLE
Marcar fuzzy párrafo

### DIFF
--- a/library/xmlrpc.client.po
+++ b/library/xmlrpc.client.po
@@ -11,16 +11,16 @@ msgstr ""
 "Project-Id-Version: Python 3.8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-05-05 12:54+0200\n"
-"PO-Revision-Date: 2020-10-31 23:26+0100\n"
+"PO-Revision-Date: 2020-11-21 20:32-0300\n"
 "Language-Team: python-doc-es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Last-Translator: \n"
+"Last-Translator: Emmanuel Arias <eamanu@yaerobi.com>\n"
 "Language: es\n"
-"X-Generator: Poedit 2.3.1\n"
+"X-Generator: Poedit 2.4.2\n"
 
 #: ../Doc/library/xmlrpc.client.rst:2
 msgid ":mod:`xmlrpc.client` --- XML-RPC client access"
@@ -597,6 +597,7 @@ msgstr ""
 "objeto de flujo *out*."
 
 #: ../Doc/library/xmlrpc.client.rst:336
+#, fuzzy
 msgid ""
 "The encoded data will have newlines every 76 characters as per :rfc:`RFC "
 "2045 section 6.8 <2045#section-6.8>`, which was the de facto standard base64 "


### PR DESCRIPTION
Tal como se ve en https://github.com/python/python-docs-es/issues/1150
Por algún motivo pospell lanza un error en la línea de RFC.

Se marca ese PR como fuzzy para que pospell no lance el mensaje de
error.