### PR TITLE
Traducido reference/expressions

### DIFF
--- a/dictionaries/reference_expressions.txt
+++ b/dictionaries/reference_expressions.txt
@@ -1,0 +1,9 @@
+Subgenerador
+close
+contraintuitiva
+contraintuitivo
+reflexibilidad
+superconjuntos
+superconjuntos
+lexicográficamente
+unarios

--- a/reference/expressions.po
+++ b/reference/expressions.po
@@ -6,28 +6,30 @@
 # Check https://github.com/python/python-docs-es/blob/3.8/TRANSLATORS to
 # get the list of volunteers
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Python 3.8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-05-05 12:54+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"PO-Revision-Date: 2020-12-06 14:19+0100\n"
 "Language-Team: python-doc-es\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.8.0\n"
+"Last-Translator: Álvaro Mondéjar Rubio <mondejar1994@gmail.com>\n"
+"Language: es\n"
+"X-Generator: Poedit 2.4.2\n"
 
 #: ../Doc/reference/expressions.rst:6
 msgid "Expressions"
-msgstr ""
+msgstr "Expresiones"
 
 #: ../Doc/reference/expressions.rst:10
 msgid ""
 "This chapter explains the meaning of the elements of expressions in Python."
 msgstr ""
+"Este capítulo explica el significado de los elementos de expresiones en "
+"Python."
 
 #: ../Doc/reference/expressions.rst:12
 msgid ""
@@ -35,16 +37,21 @@ msgid ""
 "will be used to describe syntax, not lexical analysis.  When (one "
 "alternative of) a syntax rule has the form"
 msgstr ""
+"**Notas de Sintaxis:** En este y los siguientes capítulos será usada "
+"notación BNF extendida para describir sintaxis, no análisis léxico. Cuando "
+"(una alternativa de) una regla de sintaxis tiene la forma"
 
 #: ../Doc/reference/expressions.rst:19
 msgid ""
 "and no semantics are given, the semantics of this form of ``name`` are the "
 "same as for ``othername``."
 msgstr ""
+"y no han sido dadas semánticas, las semánticas de esta forma de ``name`` son "
+"las mismas que para ``othername``."
 
 #: ../Doc/reference/expressions.rst:26
 msgid "Arithmetic conversions"
-msgstr ""
+msgstr "Conversiones aritméticas"
 
 #: ../Doc/reference/expressions.rst:30
 msgid ""
@@ -52,21 +59,29 @@ msgid ""
 "numeric arguments are converted to a common type\", this means that the "
 "operator implementation for built-in types works as follows:"
 msgstr ""
+"Cuando una descripción de un operador aritmético a continuación usa la frase "
+"\"los argumentos numéricos son convertidos a un tipo común\", esto significa "
+"que la implementación de operador para tipos incorporados funciona de la "
+"siguiente forma:"
 
 #: ../Doc/reference/expressions.rst:34
 msgid ""
 "If either argument is a complex number, the other is converted to complex;"
 msgstr ""
+"Si cualquiera de los argumentos es un número complejo, el otro es convertido "
+"a complejo;"
 
 #: ../Doc/reference/expressions.rst:36
 msgid ""
 "otherwise, if either argument is a floating point number, the other is "
 "converted to floating point;"
 msgstr ""
+"de otra forma, si cualquier de los argumentos es un número de punto "
+"flotante, el otro es convertido a punto flotante;"
 
 #: ../Doc/reference/expressions.rst:39
 msgid "otherwise, both must be integers and no conversion is necessary."
-msgstr ""
+msgstr "de otra forma, ambos deben ser enteros y no se necesita conversión."
 
 #: ../Doc/reference/expressions.rst:41
 msgid ""
@@ -74,10 +89,13 @@ msgid ""
 "argument to the '%' operator).  Extensions must define their own conversion "
 "behavior."
 msgstr ""
+"Algunas reglas adicionales aplican para ciertos operadores (ej., una cadena "
+"de caracteres como argumento a la izquierda del operador '%'). Las "
+"extensiones deben definir su comportamiento de conversión."
 
 #: ../Doc/reference/expressions.rst:49
 msgid "Atoms"
-msgstr ""
+msgstr "Átomos"
 
 #: ../Doc/reference/expressions.rst:53
 msgid ""
@@ -85,10 +103,14 @@ msgid ""
 "identifiers or literals.  Forms enclosed in parentheses, brackets or braces "
 "are also categorized syntactically as atoms.  The syntax for atoms is:"
 msgstr ""
+"Los átomos son los elementos más básicos de las expresiones. Los átomos más "
+"simples son identificadores o literales. Las formas encerradas en "
+"paréntesis, corchetes o llaves son también sintácticamente categorizadas "
+"como átomos. La sintaxis para átomos es:"
 
 #: ../Doc/reference/expressions.rst:66
 msgid "Identifiers (Names)"
-msgstr ""
+msgstr "Identificadores (Nombres)"
 
 #: ../Doc/reference/expressions.rst:70
 msgid ""
@@ -96,6 +118,9 @@ msgid ""
 "`identifiers` for lexical definition and section :ref:`naming` for "
 "documentation of naming and binding."
 msgstr ""
+"Un identificador encontrándose como un átomo es un nombre. Vea la sección :"
+"ref:`identifiers` para la definición léxica y la sección :ref:`naming` para "
+"documentación de nombrar y vincular."
 
 #: ../Doc/reference/expressions.rst:76
 msgid ""
@@ -103,6 +128,9 @@ msgid ""
 "object. When a name is not bound, an attempt to evaluate it raises a :exc:"
 "`NameError` exception."
 msgstr ""
+"Cuando el nombre es vinculado a un objeto, la evaluación del átomo produce "
+"ese objeto. Cuando un nombre no es vinculado, un intento de evaluarlo genera "
+"una excepción :exc:`NameError`."
 
 #: ../Doc/reference/expressions.rst:84
 msgid ""
@@ -119,14 +147,29 @@ msgid ""
 "implementation defined truncation may happen. If the class name consists "
 "only of underscores, no transformation is done."
 msgstr ""
+"**Alteración de nombre privado:** Cuando un identificador que ocurre "
+"textualmente en una definición de clase comienza con dos o más caracteres de "
+"guión bajo y no termina en dos o más guiones bajos, es considerado un :dfn:"
+"`private name` de esa clase. Los nombres privados son transformados a una "
+"forma más larga antes de que sea generado código para ellos. La "
+"transformación inserta el nombre de clase, con los guiones bajos iniciales "
+"eliminados y un solo guión bajo insertado, delante del nombre. Por ejemplo, "
+"el identificador ``__spam`` que se encuentra en una clase denominada ``Ham`` "
+"será transformado a ``_Ham__spam``. Esta transformación es independiente del "
+"contexto sintáctico en el cual es usado el identificador. Si el nombre "
+"transformado es extremadamente largo (más largo que 255 caracteres), puede "
+"ocurrir el truncamiento definido por la implementación. Si el nombre de "
+"clase consiste únicamente de guiones bajos, no se realiza transformación."
 
 #: ../Doc/reference/expressions.rst:100
 msgid "Literals"
-msgstr ""
+msgstr "Literales"
 
 #: ../Doc/reference/expressions.rst:104
 msgid "Python supports string and bytes literals and various numeric literals:"
 msgstr ""
+"Python soporta literales de cadenas de caracteres y bytes y varios literales "
+"numéricos:"
 
 #: ../Doc/reference/expressions.rst:110
 msgid ""
@@ -135,6 +178,11 @@ msgid ""
 "value may be approximated in the case of floating point and imaginary "
 "(complex) literals.  See section :ref:`literals` for details."
 msgstr ""
+"La evaluación de un literal produce un objeto del tipo dado (cadena de "
+"caracteres, bytes, entero, número de punto flotante, número complejo) con el "
+"valor dado. El valor puede ser aproximado en el caso de literales de número "
+"de punto flotante e imaginarios (complejos). Vea la sección :ref:`literals` "
+"para más detalles."
 
 #: ../Doc/reference/expressions.rst:119
 msgid ""
@@ -144,15 +192,22 @@ msgid ""
 "different occurrence) may obtain the same object or a different object with "
 "the same value."
 msgstr ""
+"Todos los literales corresponden a tipos de datos inmutables y, por lo "
+"tanto, la identidad del objeto es menos importante que su valor. Múltiples "
+"evaluaciones de literales con el mismo valor (ya sea la misma ocurrencia en "
+"el texto del programa o una ocurrencia diferente) pueden obtener el mismo "
+"objeto o un objeto diferente con el mismo valor."
 
 #: ../Doc/reference/expressions.rst:129
 msgid "Parenthesized forms"
-msgstr ""
+msgstr "Formas entre paréntesis"
 
 #: ../Doc/reference/expressions.rst:135
 msgid ""
 "A parenthesized form is an optional expression list enclosed in parentheses:"
 msgstr ""
+"Una forma entre paréntesis es una lista de expresiones opcionales encerradas "
+"entre paréntesis:"
 
 #: ../Doc/reference/expressions.rst:140
 msgid ""
@@ -160,6 +215,9 @@ msgid ""
 "if the list contains at least one comma, it yields a tuple; otherwise, it "
 "yields the single expression that makes up the expression list."
 msgstr ""
+"Una expresión entre paréntesis produce lo que la lista de expresión produce: "
+"si la lista contiene al menos una coma, produce una tupla; en caso "
+"contrario, produce la única expresión que que forma la lista de expresiones."
 
 #: ../Doc/reference/expressions.rst:146
 msgid ""
@@ -167,6 +225,10 @@ msgid ""
 "immutable, the same rules as for literals apply (i.e., two occurrences of "
 "the empty tuple may or may not yield the same object)."
 msgstr ""
+"Un par de paréntesis vacío producen un objeto de tupla vacío. Debido a que "
+"las tuplas son inmutables, se aplican las mismas reglas que aplican para "
+"literales (ej., dos ocurrencias de una tupla vacía puede o no producir el "
+"mismo objeto)."
 
 #: ../Doc/reference/expressions.rst:154
 msgid ""
@@ -175,30 +237,40 @@ msgid ""
 "*are* required --- allowing unparenthesized \"nothing\" in expressions would "
 "cause ambiguities and allow common typos to pass uncaught."
 msgstr ""
+"Note que las tuplas no son formadas por los paréntesis, sino más bien "
+"mediante el uso del operador de coma. La excepción es la tupla vacía, para "
+"la cual los paréntesis *son* requeridos -- permitir \"nada\" sin paréntesis "
+"en expresiones causaría ambigüedades y permitiría que errores tipográficos "
+"comunes pasaran sin ser detectados."
 
 #: ../Doc/reference/expressions.rst:163
 msgid "Displays for lists, sets and dictionaries"
-msgstr ""
+msgstr "Despliegues para listas, conjuntos y diccionarios"
 
 #: ../Doc/reference/expressions.rst:165
 msgid ""
 "For constructing a list, a set or a dictionary Python provides special "
 "syntax called \"displays\", each of them in two flavors:"
 msgstr ""
+"Para construir una lista, un conjunto o un diccionario, Python provee "
+"sintaxis especial denominada \"despliegue\", cada una de ellas en dos "
+"sabores:"
 
 #: ../Doc/reference/expressions.rst:168
 msgid "either the container contents are listed explicitly, or"
-msgstr ""
+msgstr "los contenidos del contenedor son listados explícitamente o"
 
 #: ../Doc/reference/expressions.rst:170
 msgid ""
 "they are computed via a set of looping and filtering instructions, called a :"
 "dfn:`comprehension`."
 msgstr ""
+"son calculados mediante un conjunto de instrucciones de bucle y filtrado, "
+"denominadas una :dfn:`comprehension`."
 
 #: ../Doc/reference/expressions.rst:178
 msgid "Common syntax elements for comprehensions are:"
-msgstr ""
+msgstr "Los elementos comunes de sintaxis para las comprensiones son:"
 
 #: ../Doc/reference/expressions.rst:186
 msgid ""
@@ -209,6 +281,13 @@ msgid ""
 "if` clauses a block, nesting from left to right, and evaluating the "
 "expression to produce an element each time the innermost block is reached."
 msgstr ""
+"La comprensión consiste en una única expresión seguida por al menos una "
+"cláusula :keyword:`!for` y cero o más cláusulas :keyword:`!for` o :keyword:`!"
+"if`. En este caso, los elementos del nuevo contenedor son aquellos que "
+"serían producidos mediante considerar cada una de las cláusulas :keyword:`!"
+"for` o :keyword:`!if` un bloque, anidado de izquierda a derecha y evaluando "
+"la expresión para producir un elemento cada vez que se alcanza el bloque más "
+"interno."
 
 #: ../Doc/reference/expressions.rst:193
 msgid ""
@@ -217,6 +296,10 @@ msgid ""
 "This ensures that names assigned to in the target list don't \"leak\" into "
 "the enclosing scope."
 msgstr ""
+"Sin embargo, aparte de la expresión iterable en la cláusula :keyword:`!for` "
+"más a la izquierda, la comprensión es ejecutada en un alcance separado "
+"implícitamente anidado. Esto asegura que los nombres asignados a en la lista "
+"objetiva no se \"filtren\" en el alcance adjunto."
 
 #: ../Doc/reference/expressions.rst:197
 msgid ""
@@ -227,6 +310,13 @@ msgid ""
 "enclosing scope as they may depend on the values obtained from the leftmost "
 "iterable. For example: ``[x*y for x in range(10) for y in range(x, x+10)]``."
 msgstr ""
+"La expresión iterable en la cláusula más a la izquierda :keyword:`!for` es "
+"evaluada directamente en el alcance anidado y luego pasada como un argumento "
+"al alcance implícitamente anidado. Subsecuentes cláusulas :keyword:`!for` y "
+"cualquier condición de filtro en la cláusula :keyword:`!for` más a la "
+"izquierda no pueden ser evaluadas en el alcance adjunto ya que pueden "
+"depender de los valores obtenidos del iterable de más a la izquierda. Por "
+"ejemplo, ``[x*y for x in range(10) for y in range(x, x+10)]``."
 
 #: ../Doc/reference/expressions.rst:204
 msgid ""
@@ -234,6 +324,9 @@ msgid ""
 "type, ``yield`` and ``yield from`` expressions are prohibited in the "
 "implicitly nested scope."
 msgstr ""
+"Para asegurar que la comprensión siempre resulta en un contenedor del tipo "
+"apropiado, las expresiones ``yield`` y ``yield from`` están prohibidas en el "
+"alcance implícitamente anidado."
 
 #: ../Doc/reference/expressions.rst:211
 msgid ""
@@ -248,24 +341,37 @@ msgid ""
 "asynchronous comprehension may suspend the execution of the coroutine "
 "function in which it appears. See also :pep:`530`."
 msgstr ""
+"A partir de Python 3.6, en una función :keyword:`async def`, una cláusula :"
+"keyword:`!async for` puede ser usada para iterar sobre un :term:"
+"`asynchronous iterator`. Una comprensión en una función :keyword:`!async "
+"def` puede consistir en una cláusula :keyword:`!for` o :keyword:`!async for` "
+"siguiendo la expresión inicial, puede contener cláusulas adicionales :"
+"keyword:`!for` o :keyword:`!async for` y también pueden usar expresiones :"
+"keyword:`await`. Si una comprensión contiene cláusulas :keyword:`!async for` "
+"o expresiones :keyword:`!await` es denominada una :dfn:`asynchronous "
+"comprehension`. Una comprensión asincrónica puede suspender la ejecución de "
+"la función de corrutina en la cual aparece. Vea también :pep:`530`."
 
 #: ../Doc/reference/expressions.rst:223
 msgid "Asynchronous comprehensions were introduced."
-msgstr ""
+msgstr "Fueron introducidas las comprensiones asincrónicas."
 
 #: ../Doc/reference/expressions.rst:226 ../Doc/reference/expressions.rst:397
 msgid "``yield`` and ``yield from`` prohibited in the implicitly nested scope."
 msgstr ""
+"Prohibidas ``yield`` y ``yield from`` en el alcance implícitamente anidado."
 
 #: ../Doc/reference/expressions.rst:233
 msgid "List displays"
-msgstr ""
+msgstr "Despliegues de lista"
 
 #: ../Doc/reference/expressions.rst:243
 msgid ""
 "A list display is a possibly empty series of expressions enclosed in square "
 "brackets:"
 msgstr ""
+"Un despliegue de lista es una serie de expresiones posiblemente vacía "
+"encerrada entre corchetes:"
 
 #: ../Doc/reference/expressions.rst:249
 msgid ""
@@ -276,16 +382,25 @@ msgid ""
 "is supplied, the list is constructed from the elements resulting from the "
 "comprehension."
 msgstr ""
+"Un despliegue de lista produce un nuevo objeto lista, el contenido se "
+"especifica por una lista de expresiones o una comprensión. Cuando se "
+"proporciona una lista de expresiones, sus elementos son evaluados desde la "
+"izquierda a la derecha y colocados en el objeto lista en ese orden. Cuando "
+"se proporciona una comprensión, la lista es construida desde los elementos "
+"resultantes de la comprensión."
 
 #: ../Doc/reference/expressions.rst:259
 msgid "Set displays"
-msgstr ""
+msgstr "Despliegues de conjuntos"
 
 #: ../Doc/reference/expressions.rst:267
 msgid ""
 "A set display is denoted by curly braces and distinguishable from dictionary "
 "displays by the lack of colons separating keys and values:"
 msgstr ""
+"Un despliegue de conjunto se denota mediante llaves y se distinguen de los "
+"despliegues de diccionarios por la ausencia de caracteres de doble punto "
+"separando claves y valores:"
 
 #: ../Doc/reference/expressions.rst:273
 msgid ""
@@ -296,26 +411,36 @@ msgid ""
 "supplied, the set is constructed from the elements resulting from the "
 "comprehension."
 msgstr ""
+"Un despliegue de conjunto produce un nuevo objeto conjunto mutable, el "
+"contenido se especifica mediante una secuencia de expresiones o una "
+"comprensión. Cuando se proporciona una lista de expresiones separadas por "
+"comas, sus elementos son evaluados desde la izquierda a la derecha y "
+"añadidos al objeto de conjunto. Cuando se proporciona una comprensión, el "
+"conjunto es construido de los elementos resultantes de la comprensión."
 
 #: ../Doc/reference/expressions.rst:279
 msgid ""
 "An empty set cannot be constructed with ``{}``; this literal constructs an "
 "empty dictionary."
 msgstr ""
+"Un conjunto vacío no puede ser construido con ``{}``; este literal construye "
+"un diccionario vacío."
 
 #: ../Doc/reference/expressions.rst:286
 msgid "Dictionary displays"
-msgstr ""
+msgstr "Despliegues de diccionario"
 
 #: ../Doc/reference/expressions.rst:296
 msgid ""
 "A dictionary display is a possibly empty series of key/datum pairs enclosed "
 "in curly braces:"
 msgstr ""
+"Un despliegue de diccionario es una serie posiblemente vacía de pares clave/"
+"datos encerrados entre llaves:"
 
 #: ../Doc/reference/expressions.rst:305
 msgid "A dictionary display yields a new dictionary object."
-msgstr ""
+msgstr "Un despliegue de diccionario produce un nuevo objeto diccionario."
 
 #: ../Doc/reference/expressions.rst:307
 msgid ""
@@ -326,6 +451,12 @@ msgid ""
 "key/datum list, and the final dictionary's value for that key will be the "
 "last one given."
 msgstr ""
+"Si es dada una secuencia separada por comas de pares clave/datos, son "
+"evaluadas desde la izquierda a la derecha para definir las entradas del "
+"diccionario: cada objeto clave es usado como una clave dentro del "
+"diccionario para almacenar el dato correspondiente. Esto significa que "
+"puedes especificar la misma clave múltiples veces en la lista clave/datos y "
+"el valor final del diccionario para esa clave será la última dada."
 
 #: ../Doc/reference/expressions.rst:317
 msgid ""
@@ -334,10 +465,16 @@ msgid ""
 "dictionary.  Later values replace values already set by earlier key/datum "
 "pairs and earlier dictionary unpackings."
 msgstr ""
+"Un doble asterisco ``**`` denota :dfn:`dictionary unpacking`. Su operando "
+"debe ser un :term:`mapping`. Cada elemento de mapeo es añadido al nuevo "
+"diccionario. Valores más tardíos remplazan los valores ya establecidos para "
+"los pares clave/dato y para los desempaquetados de diccionario anteriores."
 
 #: ../Doc/reference/expressions.rst:322
 msgid "Unpacking into dictionary displays, originally proposed by :pep:`448`."
 msgstr ""
+"Desempaquetar en despliegues de diccionarios, originalmente propuesto por :"
+"pep:`448`."
 
 #: ../Doc/reference/expressions.rst:325
 msgid ""
@@ -346,6 +483,11 @@ msgid ""
 "clauses. When the comprehension is run, the resulting key and value elements "
 "are inserted in the new dictionary in the order they are produced."
 msgstr ""
+"Una comprensión de diccionario, en contraste a las compresiones de lista y "
+"conjunto, necesita dos expresiones separadas con un caracter de doble punto "
+"seguido por las cláusulas usuales \"for\" e \"if\". Cuando la comprensión se "
+"ejecuta, los elementos resultantes clave y valor son insertados en el nuevo "
+"diccionario en el orden que son producidos."
 
 #: ../Doc/reference/expressions.rst:333
 msgid ""
@@ -355,6 +497,11 @@ msgid ""
 "detected; the last datum (textually rightmost in the display) stored for a "
 "given key value prevails."
 msgstr ""
+"Las restricciones de los tipos de los valores de clave son listados "
+"anteriormente en la sección :ref:`types`. (Para resumir, el tipo de la clave "
+"debe ser :term:`hashable`, el cual excluye todos los objetos mutables.) No "
+"se detectan choques entre claves duplicadas; el último dato (textualmente el "
+"más a la derecha en el despliegue) almacenado para una clave dada prevalece."
 
 #: ../Doc/reference/expressions.rst:339
 msgid ""
@@ -363,14 +510,20 @@ msgid ""
 "key.  Starting with 3.8, the key is evaluated before the value, as proposed "
 "by :pep:`572`."
 msgstr ""
+"Antes de Python 3.8, en las comprensiones de diccionarios, el orden de "
+"evaluación de clave y valor no fue bien definido. En CPython, el valor fue "
+"evaluado antes de la clave. A partir de 3.8, la clave es evaluada antes que "
+"el valor, como fue propuesto por :pep:`572`."
 
 #: ../Doc/reference/expressions.rst:349
 msgid "Generator expressions"
-msgstr ""
+msgstr "Expresiones de generador"
 
 #: ../Doc/reference/expressions.rst:356
 msgid "A generator expression is a compact generator notation in parentheses:"
 msgstr ""
+"Una expresión de generador es una notación compacta de generador en "
+"paréntesis:"
 
 #: ../Doc/reference/expressions.rst:361
 msgid ""
@@ -378,6 +531,9 @@ msgid ""
 "same as for comprehensions, except that it is enclosed in parentheses "
 "instead of brackets or curly braces."
 msgstr ""
+"Una expresión de generador produce un nuevo objeto generador. Su sintaxis es "
+"la misma que para las comprensiones, excepto que es encerrado en paréntesis "
+"en lugar de corchetes o llaves."
 
 #: ../Doc/reference/expressions.rst:365
 msgid ""
@@ -392,12 +548,25 @@ msgid ""
 "depend on the values obtained from the leftmost iterable. For example: "
 "``(x*y for x in range(10) for y in range(x, x+10))``."
 msgstr ""
+"Las variables usadas en la expresión de generador son evaluadas "
+"perezosamente cuando se ejecuta el método :meth:`~generator.__next__` para "
+"el objeto generador (de la misma forma que los generadores normales). Sin "
+"embargo, la expresión iterable en la cláusula :keyword:`!for` más a la "
+"izquierda es inmediatamente evaluada, de forma que un error producido por "
+"ella será emitido en el punto en el que se define la expresión de generador, "
+"en lugar de en el punto donde se obtiene el primer valor. Subsecuentes "
+"cláusulas :keyword:`!for` y cualquier condición en la cláusula :keyword:`!"
+"for` más a la izquierda no pueden ser evaluadas en el alcance adjunto, ya "
+"que puede depender de los valores obtenidos por el iterable de más a la "
+"izquierda. Por ejemplo: ``(x*y for x in range(10) for y in range(x, x+10))``."
 
 #: ../Doc/reference/expressions.rst:376
 msgid ""
 "The parentheses can be omitted on calls with only one argument.  See "
 "section :ref:`calls` for details."
 msgstr ""
+"Los paréntesis pueden ser omitidos en ejecuciones con un solo argumento. Vea "
+"la sección :ref:`calls` para más detalles."
 
 #: ../Doc/reference/expressions.rst:379
 msgid ""
@@ -405,6 +574,9 @@ msgid ""
 "itself, ``yield`` and ``yield from`` expressions are prohibited in the "
 "implicitly defined generator."
 msgstr ""
+"Para evitar interferir con la operación esperada de la expresión misma del "
+"generador, las expresiones ``yield`` y ``yield from`` están prohibidas en el "
+"generador definido implícitamente."
 
 #: ../Doc/reference/expressions.rst:383
 msgid ""
@@ -414,10 +586,15 @@ msgid ""
 "asynchronous generator object, which is an asynchronous iterator (see :ref:"
 "`async-iterators`)."
 msgstr ""
+"Si una expresión de generador contiene cláusulas :keyword:`!async for` o "
+"expresiones :keyword:`await`, se ejecuta una :dfn:`asynchronous generator "
+"expression`. Una expresión de generador asincrónica retorna un nuevo objeto "
+"de generador asincrónico, el cual es un iterador asincrónico (ver :ref:"
+"`async-iterators`)."
 
 #: ../Doc/reference/expressions.rst:389
 msgid "Asynchronous generator expressions were introduced."
-msgstr ""
+msgstr "Las expresiones de generador asincrónico fueron introducidas."
 
 #: ../Doc/reference/expressions.rst:392
 msgid ""
@@ -425,10 +602,13 @@ msgid ""
 "in :keyword:`async def` coroutines.  Starting with 3.7, any function can use "
 "asynchronous generator expressions."
 msgstr ""
+"Antes de Python 3.7, las expresiones de generador asincrónico podrían "
+"aparecer sólo en corrutinas :keyword:`async def`. Desde 3.7, cualquier "
+"función puede usar expresiones de generador asincrónico."
 
 #: ../Doc/reference/expressions.rst:404
 msgid "Yield expressions"
-msgstr ""
+msgstr "Expresiones yield"
 
 #: ../Doc/reference/expressions.rst:416
 msgid ""
@@ -439,6 +619,12 @@ msgid ""
 "`async def` function's body causes that coroutine function to be an "
 "asynchronous generator. For example::"
 msgstr ""
+"La expresión yield se usa al definir una función :term:`generator` o una "
+"función :term:`asynchronous generator` y, por lo tanto, solo se puede usar "
+"en el cuerpo de una definición de función. Usar una expresión yield en el "
+"cuerpo de una función hace que esa función sea un generador y usarla en el "
+"cuerpo de una función :keyword:`async def` hace que la función de corrutina "
+"sea un generador asincrónico. Por ejemplo::"
 
 #: ../Doc/reference/expressions.rst:429
 msgid ""
@@ -446,12 +632,18 @@ msgid ""
 "not permitted as part of the implicitly defined scopes used to implement "
 "comprehensions and generator expressions."
 msgstr ""
+"Debido a sus efectos secundarios sobre el alcance contenedor, las "
+"expresiones ``yield`` no están permitidas como parte de los alcances "
+"implícitamente definidos usados para implementar comprensiones y expresiones "
+"de generador."
 
 #: ../Doc/reference/expressions.rst:433
 msgid ""
 "Yield expressions prohibited in the implicitly nested scopes used to "
 "implement comprehensions and generator expressions."
 msgstr ""
+"Expresiones yield prohibidas en los ámbitos anidados implícitamente "
+"utilizados para implementar comprensiones y expresiones de generador."
 
 #: ../Doc/reference/expressions.rst:437
 msgid ""
@@ -459,6 +651,9 @@ msgid ""
 "functions are described separately in section :ref:`asynchronous-generator-"
 "functions`."
 msgstr ""
+"Las funciones generadoras son descritas a continuación, mientras que las "
+"funciones generadoras asincrónicas son descritas separadamente en la "
+"sección :ref:`asynchronous-generator-functions`."
 
 #: ../Doc/reference/expressions.rst:441
 msgid ""
@@ -479,6 +674,22 @@ msgid ""
 "`~generator.send` is used, then the result will be the value passed in to "
 "that method."
 msgstr ""
+"Cuando una función generadora es invocada, retorna un iterador conocido como "
+"un generador. Este generador controla la ejecución de la función generadora. "
+"La ejecución empieza cuando uno de los métodos del generador es invocado. En "
+"ese momento, la ejecución procede a la primera expresión yield, donde es "
+"suspendida de nuevo, retornando el valor de :token:`expression_list` al "
+"invocador del generador. Por suspendido, nos referimos a que se retiene todo "
+"el estado local, incluyendo los enlaces actuales de variables locales, el "
+"puntero de instrucción, la pila de evaluación interna y el estado de "
+"cualquier manejo de excepción. Cuando la ejecución se reanuda al invocar uno "
+"de los métodos del generador, la función puede proceder como si la expresión "
+"yield fuera sólo otra invocación externa. El valor de la expresión yield "
+"después de la reanudación depende del método que ha reanudado la ejecución. "
+"Si se usa :meth:`~generator.__next__` (típicamente mediante un :keyword:"
+"`for` o la función incorporada :func:`next`) entonces el resultado es :const:"
+"`None`. De otra forma, si se usa :meth:`~generator.send`, entonces el "
+"resultado será el valor pasado a ese método."
 
 #: ../Doc/reference/expressions.rst:460
 msgid ""
@@ -488,6 +699,11 @@ msgid ""
 "function cannot control where the execution should continue after it yields; "
 "the control is always transferred to the generator's caller."
 msgstr ""
+"Todo este hace a las funciones generadores similar a las corrutinas; "
+"producen múltiples veces, tienen más de un punto de entrada y su ejecución "
+"puede ser suspendida. La única diferencia es que una función generadora no "
+"puede controlar si la ejecución debe continuar después de producir; el "
+"control siempre es transferido al invocador del generador."
 
 #: ../Doc/reference/expressions.rst:466
 msgid ""
@@ -497,6 +713,11 @@ msgid ""
 "meth:`~generator.close` method will be called, allowing any pending :keyword:"
 "`finally` clauses to execute."
 msgstr ""
+"Las expresiones yield están permitidas en cualquier lugar en un constructo :"
+"keyword:`try`. Si el generador no es reanudado antes de finalizar "
+"(alcanzando un recuento de referencia cero o colectando basura), el método "
+"generador-iterador :meth:`~generator.close` será invocado, permitiendo la "
+"ejecución de cualquier cláusula :keyword:`finally` pendiente."
 
 #: ../Doc/reference/expressions.rst:475
 msgid ""
@@ -509,6 +730,15 @@ msgid ""
 "exc:`AttributeError` or :exc:`TypeError`, while :meth:`~generator.throw` "
 "will just raise the passed in exception immediately."
 msgstr ""
+"Cuando se usa ``yield from <expr>``, esto trata a la expresión provista como "
+"un subiterador. Todos los valores producidos por ese subiterador son pasados "
+"directamente al invocador de los métodos del generador actual. Cualquiera de "
+"los valores pasados con :meth:`~generator.send` y cualquiera de las "
+"excepciones pasadas con :meth:`~generator.throw` son pasados al iterador "
+"subyacente si tiene los métodos apropiados. Si este no es el caso, entonces :"
+"meth:`~generator.send` generará :exc:`AttributeError` o :exc:`TypeError`, "
+"mientras :meth:`~generator.throw` sólo generará inmediatamente la excepción "
+"pasada."
 
 #: ../Doc/reference/expressions.rst:484
 msgid ""
@@ -518,72 +748,94 @@ msgid ""
 "`StopIteration`, or automatically when the subiterator is a generator (by "
 "returning a value from the subgenerator)."
 msgstr ""
+"Cuando el iterador subyacente está completo, el atributo :attr:"
+"`~StopIteration.value` de la instancia :exc:`StopIteration` generada se "
+"convierte en el valor de la expresión yield. Puede ser establecido "
+"explícitamente al generar :exc:`StopIteration` o automáticamente cuando el "
+"subiterador es un generador (retornando un valor del subgenerador)."
 
 #: ../Doc/reference/expressions.rst:490
 msgid "Added ``yield from <expr>`` to delegate control flow to a subiterator."
 msgstr ""
+"Añadido ``yield from <expr>`` para delegar el control de flujo a un "
+"subiterador."
 
 #: ../Doc/reference/expressions.rst:493
 msgid ""
 "The parentheses may be omitted when the yield expression is the sole "
 "expression on the right hand side of an assignment statement."
 msgstr ""
+"Los paréntesis pueden ser omitidos cuando la expresión yield es la única "
+"expresión en el lado derecho de una sentencia de asignación."
 
 #: ../Doc/reference/expressions.rst:499
 msgid ":pep:`255` - Simple Generators"
-msgstr ""
+msgstr ":pep:`255` - Generadores Simples"
 
 #: ../Doc/reference/expressions.rst:499
 msgid ""
 "The proposal for adding generators and the :keyword:`yield` statement to "
 "Python."
 msgstr ""
+"La propuesta para añadir generadores y la sentencia :keyword:`yield` a "
+"Python."
 
 #: ../Doc/reference/expressions.rst:503
 msgid ":pep:`342` - Coroutines via Enhanced Generators"
-msgstr ""
+msgstr ":pep:`342` - Corrutinas mediante Generadores Mejorados"
 
 #: ../Doc/reference/expressions.rst:502
 msgid ""
 "The proposal to enhance the API and syntax of generators, making them usable "
 "as simple coroutines."
 msgstr ""
+"La propuesta para mejorar la API y la sintaxis de generadores, haciéndolos "
+"utilizables como corrutinas simples."
 
 #: ../Doc/reference/expressions.rst:507
 msgid ":pep:`380` - Syntax for Delegating to a Subgenerator"
-msgstr ""
+msgstr ":pep:`380` - Sintaxis para Delegar a un Subgenerador"
 
 #: ../Doc/reference/expressions.rst:506
 msgid ""
 "The proposal to introduce the :token:`yield_from` syntax, making delegation "
 "to subgenerators easy."
 msgstr ""
+"La propuesta para introducir la sintaxis :token:`yield_from`, facilitando la "
+"delegación a subgeneradores."
 
 #: ../Doc/reference/expressions.rst:510
 msgid ":pep:`525` - Asynchronous Generators"
-msgstr ""
+msgstr ":pep:`525`- Generadores Asincrónicos"
 
 #: ../Doc/reference/expressions.rst:510
 msgid ""
 "The proposal that expanded on :pep:`492` by adding generator capabilities to "
 "coroutine functions."
 msgstr ""
+"La propuesta que expandió :pep:`492` añadiendo capacidades de generador a "
+"las funciones corrutina."
 
 #: ../Doc/reference/expressions.rst:517
 msgid "Generator-iterator methods"
-msgstr ""
+msgstr "Métodos generador-iterador"
 
 #: ../Doc/reference/expressions.rst:519
 msgid ""
 "This subsection describes the methods of a generator iterator.  They can be "
 "used to control the execution of a generator function."
 msgstr ""
+"Esta subsección describe los métodos de un generador iterador. Estos pueden "
+"ser usados para controlar la ejecución de una función generadora."
 
 #: ../Doc/reference/expressions.rst:522
 msgid ""
 "Note that calling any of the generator methods below when the generator is "
 "already executing raises a :exc:`ValueError` exception."
 msgstr ""
+"Tenga en cuenta que invocar cualquiera de los métodos de generador "
+"siguientes cuando el generador está todavía en ejecución genera una "
+"excepción :exc:`ValueError`."
 
 #: ../Doc/reference/expressions.rst:530
 msgid ""
@@ -596,12 +848,22 @@ msgid ""
 "generator exits without yielding another value, a :exc:`StopIteration` "
 "exception is raised."
 msgstr ""
+"Comienza la ejecución de una función generadora o la reanuda en la última "
+"expresión yield ejecutada. Cuando una función generadora es reanudada con un "
+"método :meth:`~generator.__next__`, la expresión yield actual siempre evalúa "
+"a :const:`None`. La ejecución entonces continúa a la siguiente expresión "
+"yield, donde el generador se suspende de nuevo y el valor de :token:"
+"`expression_list` se retorna al invocador de :meth:`__next__`. Si el "
+"generador termina sin producir otro valor, se genera una excepción :exc:"
+"`StopIteration`."
 
 #: ../Doc/reference/expressions.rst:539
 msgid ""
 "This method is normally called implicitly, e.g. by a :keyword:`for` loop, or "
 "by the built-in :func:`next` function."
 msgstr ""
+"Este método es normalmente invocado implícitamente, por ejemplo, por un "
+"bucle :keyword:`for` o por la función incorporada :func:`next`."
 
 #: ../Doc/reference/expressions.rst:545
 msgid ""
@@ -613,6 +875,13 @@ msgid ""
 "called with :const:`None` as the argument, because there is no yield "
 "expression that could receive the value."
 msgstr ""
+"Reanuda la ejecución y \"envía\" un valor dentro de la función generadora. "
+"El argumento *value* se convierte en el resultado de la expresión yield "
+"actual. El método :meth:`send` retorna el siguiente valor producido por el "
+"generador o genera :exc:`StopIteration` si el generador termina sin producir "
+"otro valor. Cuando se ejecuta :meth:`send` para comenzar el generador, debe "
+"ser invocado con :const:`None` como el argumento, debido a que no hay "
+"expresión yield que pueda recibir el valor."
 
 #: ../Doc/reference/expressions.rst:556
 msgid ""
@@ -623,6 +892,12 @@ msgid ""
 "exception, or raises a different exception, then that exception propagates "
 "to the caller."
 msgstr ""
+"Genera una excepción de tipo ``type`` en el punto donde el generador fue "
+"pausado y retorna el siguiente valor producido por la función generadora. Si "
+"el generador termina sin producir otro valor se genera una excepción :exc:"
+"`StopIteration`. Si la función generadora no caza la excepción pasada o "
+"genera una excepción diferente, entonces se propaga esa excepción al "
+"invocador."
 
 #: ../Doc/reference/expressions.rst:567
 msgid ""
@@ -634,26 +909,37 @@ msgid ""
 "is propagated to the caller.  :meth:`close` does nothing if the generator "
 "has already exited due to an exception or normal exit."
 msgstr ""
+"Genera :exc:`GeneratorExit` en el punto donde la función generadora fue "
+"pausada. Si la función generadora termina sin errores, está ya cerrada o "
+"genera :exc:`GeneratorExit` (sin cazar la excepción), close retorna a su "
+"invocador. Si el generador produce un valor, se genera un :exc:"
+"`RuntimeError`. Si el generador genera cualquier otra excepción, es "
+"propagado al invocador. :meth:`close` no hace nada si el generador ya fue "
+"terminado debido a una excepción o una salida normal."
 
 #: ../Doc/reference/expressions.rst:578
 msgid "Examples"
-msgstr ""
+msgstr "Ejemplos"
 
 #: ../Doc/reference/expressions.rst:580
 msgid ""
 "Here is a simple example that demonstrates the behavior of generators and "
 "generator functions::"
 msgstr ""
+"Aquí hay un ejemplo simple que demuestra el comportamiento de generadores y "
+"funciones generadoras:"
 
 #: ../Doc/reference/expressions.rst:607
 msgid ""
 "For examples using ``yield from``, see :ref:`pep-380` in \"What's New in "
 "Python.\""
 msgstr ""
+"Para ejemplos usando ``yield from``, ver :ref:`pep-380` en \"Qué es nuevo en "
+"Python.\""
 
 #: ../Doc/reference/expressions.rst:613
 msgid "Asynchronous generator functions"
-msgstr ""
+msgstr "Funciones generadoras asincrónicas"
 
 #: ../Doc/reference/expressions.rst:615
 msgid ""
@@ -661,6 +947,9 @@ msgid ""
 "keyword:`async def` further defines the function as an :term:`asynchronous "
 "generator` function."
 msgstr ""
+"La presencia de una expresión yield en una función o método definido usando :"
+"keyword:`async def` adicionalmente define la función como una función :term:"
+"`asynchronous generator`."
 
 #: ../Doc/reference/expressions.rst:619
 msgid ""
@@ -671,6 +960,12 @@ msgid ""
 "coroutine function analogously to how a generator object would be used in a :"
 "keyword:`for` statement."
 msgstr ""
+"Cuando se invoca una función generadora asincrónica, retorna un iterador "
+"asincrónico conocido como un objeto generador asincrónico. Este objeto "
+"entonces controla la ejecución de la función generadora. Un objeto generador "
+"asincrónico se usa típicamente en una sentencia :keyword:`async for` en una "
+"función corrutina análogamente a como sería usado un objeto generador en una "
+"sentencia :keyword:`for`."
 
 #: ../Doc/reference/expressions.rst:626
 msgid ""
@@ -689,6 +984,21 @@ msgid ""
 "is :const:`None`. Otherwise, if :meth:`~agen.asend` is used, then the result "
 "will be the value passed in to that method."
 msgstr ""
+"Invocar uno de los métodos de un generador asincrónico retorna un objeto :"
+"term:`awaitable` y la ejecución comienza cuando este objeto es esperado. En "
+"ese momento, la ejecución avanza a la primera expresión yield, donde es "
+"suspendida de nuevo, retornando el valor de :token:`expression_list` a la "
+"corrutina en espera. Como con un generador, la suspensión significa que todo "
+"el estado local es retenido, incluyendo los enlaces actuales de variables "
+"locales, el puntero de instrucción, la pila de evaluación interna y el "
+"estado de cualquier manejo de excepción. Cuando se reanuda la ejecución al "
+"espera al siguiente objeto retornado por los métodos del generador "
+"asincrónico, la función puede avanzar exactamente igual que si la expresión "
+"yield fuera otra invocación externa. El valor de la expresión yield después "
+"de la reanudación dependen del método que ha resumido la ejecución. Si se "
+"usa :meth:`~agen.__anext__` entonces el resultado es :const:`None`. De otra "
+"forma, si se usa :meth:`~agen.asend`, entonces el resultado será el valor "
+"pasado a ese método."
 
 #: ../Doc/reference/expressions.rst:642
 msgid ""
@@ -703,6 +1013,16 @@ msgid ""
 "the resulting coroutine object, thus allowing any pending :keyword:`!"
 "finally` clauses to execute."
 msgstr ""
+"En una función generadora asincrónica, las expresiones yield están "
+"permitidas en cualquier lugar de un constructo :keyword:`try`. Sin embargo, "
+"si un generador asincrónico no es reanudado antes de finalizar (alcanzando "
+"un contador de referencia cero o recogiendo basura), entonces una expresión "
+"yield dentro de un constructo :keyword:`!try` podría fallar al ejecutar "
+"cláusulas :keyword:`finally` pendientes. En este caso, es responsabilidad "
+"del bucle de eventos o del planificador ejecutando el generador asincrónico "
+"invocar el método :meth:`~agen.aclose` del generador-iterador asincrónico y "
+"ejecutar el objeto corrutina resultante, permitiendo así la ejecución de "
+"cualquier cláusula :keyword:`!finally` pendiente."
 
 #: ../Doc/reference/expressions.rst:653
 msgid ""
@@ -715,22 +1035,35 @@ msgid ""
 "*finalizer* method see the implementation of ``asyncio.Loop."
 "shutdown_asyncgens`` in :source:`Lib/asyncio/base_events.py`."
 msgstr ""
+"Para encargarse de la finalización, un bucle de eventos debe definir una "
+"función *finalizadora* la cual toma un generador-iterador asincrónico y "
+"presumiblemente invoca :meth:`~agen.aclose` y ejecuta la corrutina. Este "
+"*finalizador* puede ser registrado invocando :func:`sys.set_asyncgen_hooks`. "
+"Cuando es iterada por primera vez, un generador-iterador asincrónico "
+"almacenará el *finalizador* registrado para ser invocado en la finalización. "
+"Para un ejemplo de referencia de un método *finalizador* vea la "
+"implementación de ``asyncio.Loop.shutdown_asyncgens`` en :source:`Lib/"
+"asyncio/base_events.py`."
 
 #: ../Doc/reference/expressions.rst:662
 msgid ""
 "The expression ``yield from <expr>`` is a syntax error when used in an "
 "asynchronous generator function."
 msgstr ""
+"La expresión ``yield from <expr>`` es un error de sintaxis cuando es usada "
+"en una función generadora asincrónica."
 
 #: ../Doc/reference/expressions.rst:669
 msgid "Asynchronous generator-iterator methods"
-msgstr ""
+msgstr "Métodos asincrónicos de generador-iterador"
 
 #: ../Doc/reference/expressions.rst:671
 msgid ""
 "This subsection describes the methods of an asynchronous generator iterator, "
 "which are used to control the execution of a generator function."
 msgstr ""
+"Esta subsección describe los métodos de un generador iterador asincrónico, "
+"los cuales son usados para controlar la ejecución de una función generadora."
 
 #: ../Doc/reference/expressions.rst:679
 msgid ""
@@ -745,11 +1078,23 @@ msgid ""
 "another value, the awaitable instead raises a :exc:`StopAsyncIteration` "
 "exception, signalling that the asynchronous iteration has completed."
 msgstr ""
+"Retorna un esperable el cual, cuando corre, comienza a ejecutar el generador "
+"asincrónico o lo reanuda en la última expresión yield ejecutada. Cuando se "
+"reanuda una función generadora asincrónica con un método :meth:`~agen."
+"__anext__`, la expresión yield actual siempre evalúa a :const:`None` en el "
+"esperable retornado, el cual cuando corre continuará a la siguiente "
+"expresión yield. El valor de :token:`expression_list` de la expresión yield "
+"es el valor de la excepción :exc:`StopIteration` generada por la corrutina "
+"completa. Si el generador asincrónico termina sin producir otro valor, el "
+"esperable en su lugar genera una excepción :exc:`StopAsyncIteration`, "
+"señalando que la iteración asincrónica se ha completado."
 
 #: ../Doc/reference/expressions.rst:691
 msgid ""
 "This method is normally called implicitly by a :keyword:`async for` loop."
 msgstr ""
+"Este método es invocado normalmente de forma implícita por un bucle :keyword:"
+"`async for`."
 
 #: ../Doc/reference/expressions.rst:696
 msgid ""
@@ -765,6 +1110,16 @@ msgid ""
 "`None` as the argument, because there is no yield expression that could "
 "receive the value."
 msgstr ""
+"Retorna un esperable el cual cuando corre reanuda la ejecución del generador "
+"asincrónico. Como el método :meth:`~generator.send()` para un generador, "
+"este \"envía\" un valor a la función generadora asincrónica y el argumento "
+"*value* se convierte en el resultado de la expresión yield actual. El "
+"esperable retornado por el método :meth:`asend` retornará el siguiente valor "
+"producido por el generador como el valor de la :exc:`StopIteration` generada "
+"o genera :exc:`StopAsyncIteration` si el generador asincrónico termina sin "
+"producir otro valor. Cuando se invoca :meth:`asend` para empezar el "
+"generador asincrónico, debe ser invocado con :const:`None` como argumento, "
+"porque no hay expresión yield que pueda recibir el valor."
 
 #: ../Doc/reference/expressions.rst:711
 msgid ""
@@ -777,6 +1132,14 @@ msgid ""
 "exception, or raises a different exception, then when the awaitable is run "
 "that exception propagates to the caller of the awaitable."
 msgstr ""
+"Retorna un esperable que genera una excepción de tipo ``type`` en el punto "
+"donde el generador asincrónico fue pausado y retorna el siguiente valor "
+"producido por la función generadora como el valor de la excepción :exc:"
+"`StopIteration` generada. Si el generador asincrónico termina sin producir "
+"otro valor, el esperable genera una excepción :exc:`StopAsyncIteration`. Si "
+"la función generadora no caza la excepción pasada o genera una excepción "
+"diferente, entonces cuando se ejecuta el esperable esa excepción se propaga "
+"al invocador del esperable."
 
 #: ../Doc/reference/expressions.rst:726
 msgid ""
@@ -793,24 +1156,39 @@ msgid ""
 "due to an exception or normal exit, then further calls to :meth:`aclose` "
 "will return an awaitable that does nothing."
 msgstr ""
+"Retorna un esperable que cuando corre lanza un :exc:`GeneratorExit` a la "
+"función generadora asincrónica en el punto donde fue pausada. Si la función "
+"generadora asincrónica termina exitosamente, ya está cerrada o genera  :exc:"
+"`GeneratorExit` (sin cazar la excepción), el esperable retornado generará "
+"una excepción :exc:`StopIteration`. Otros esperables retornados por "
+"subsecuentes invocaciones al generador asincrónico generarán una excepción :"
+"exc:`StopAsyncIteration`. Si el generador asincrónico produce un valor, el "
+"esperable genera un :exc:`RuntimeError`. Si el generador asincrónico genera "
+"cualquier otra excepción, esta es propagada al invocador del esperable. Si "
+"el generador asincrónico ha terminado debido a una excepción o una "
+"terminación normal, entonces futuras invocaciones a :meth:`aclose` "
+"retornarán un esperable que no hace nada."
 
 #: ../Doc/reference/expressions.rst:742
 msgid "Primaries"
-msgstr ""
+msgstr "Primarios"
 
 #: ../Doc/reference/expressions.rst:746
 msgid ""
 "Primaries represent the most tightly bound operations of the language. Their "
 "syntax is:"
 msgstr ""
+"Los primarios representan las operaciones más fuertemente ligadas al "
+"lenguaje. Su sintaxis es:"
 
 #: ../Doc/reference/expressions.rst:756
 msgid "Attribute references"
-msgstr ""
+msgstr "Referencias de atributos"
 
 #: ../Doc/reference/expressions.rst:762
 msgid "An attribute reference is a primary followed by a period and a name:"
 msgstr ""
+"Una referencia de atributo es un primario seguido de un punto y un nombre:"
 
 #: ../Doc/reference/expressions.rst:772
 msgid ""
@@ -822,16 +1200,26 @@ msgid ""
 "type and value of the object produced is determined by the object.  Multiple "
 "evaluations of the same attribute reference may yield different objects."
 msgstr ""
+"El primario debe evaluar a un objeto de un tipo que soporte referencias de "
+"atributos, lo cual la mayoría de los objetos soportan. Luego se le pide a "
+"este objeto que produzca el atributo cuyo nombre es el identificador. Esta "
+"producción puede ser personalizada sobrescribiendo el método :meth:"
+"`__getattr__`. Si este atributo no es esperable, se genera la excepción :exc:"
+"`AtributeError`. De otra forma, el tipo y el valor del objeto producido es "
+"determinado por el objeto. Múltiples evaluaciones la misma referencia de "
+"atributo pueden producir diferentes objetos."
 
 #: ../Doc/reference/expressions.rst:784
 msgid "Subscriptions"
-msgstr ""
+msgstr "Suscripciones"
 
 #: ../Doc/reference/expressions.rst:799
 msgid ""
 "A subscription selects an item of a sequence (string, tuple or list) or "
 "mapping (dictionary) object:"
 msgstr ""
+"Una subscripción selecciona un elemento de una objeto secuencia (cadena de "
+"caracteres, tupla o lista) o mapeo (diccionario):"
 
 #: ../Doc/reference/expressions.rst:805
 msgid ""
@@ -839,12 +1227,17 @@ msgid ""
 "dictionaries for example).  User-defined objects can support subscription by "
 "defining a :meth:`__getitem__` method."
 msgstr ""
+"El primario debe evaluar a un objeto que soporta subscripción (listas o "
+"diccionarios por ejemplo). Los objetos definidos por usuarios pueden "
+"soportar subscripción definiendo un método :meth:`__getitem__`."
 
 #: ../Doc/reference/expressions.rst:809
 msgid ""
 "For built-in objects, there are two types of objects that support "
 "subscription:"
 msgstr ""
+"Para objetos incorporados, hay dos tipos de objetos que soportan "
+"subscripción:"
 
 #: ../Doc/reference/expressions.rst:811
 msgid ""
@@ -853,12 +1246,18 @@ msgid ""
 "the value in the mapping that corresponds to that key.  (The expression list "
 "is a tuple except if it has exactly one item.)"
 msgstr ""
+"Si el primario es un mapeo, la expresión de lista debe evaluar a un objeto "
+"cuyo valor es una de las claves del mapeo y la subscripción selecciona el "
+"valor en el mapeo que corresponda a esa clave. (La expresión de lista es una "
+"tupla excepto si tiene exactamente un elemento.)"
 
 #: ../Doc/reference/expressions.rst:816
 msgid ""
 "If the primary is a sequence, the expression list must evaluate to an "
 "integer or a slice (as discussed in the following section)."
 msgstr ""
+"Si el primario es una secuencia, la expresión de lista debe evaluar a un "
+"entero o a un segmento (como es discutido en la siguiente sección)."
 
 #: ../Doc/reference/expressions.rst:819
 msgid ""
@@ -872,16 +1271,28 @@ msgid ""
 "slicing occurs in the object's :meth:`__getitem__` method, subclasses "
 "overriding this method will need to explicitly add that support."
 msgstr ""
+"La sintaxis formal no hace ninguna provisión especial para índices negativos "
+"en secuencias; sin embargo, todas las secuencias incorporadas proveen un "
+"método :meth:`__getitem__` que interpreta índices negativos añadiendo al "
+"largo de la secuencia al índice (así es que ``x[-1]`` selecciona el último "
+"elemento de ``x``). El valor resultante debe ser un entero no negativo menor "
+"que el número de elementos en la secuencia y la subscripción selecciona el "
+"elemento cuyo índice es ese valor (contando desde cero). Ya que el soporte "
+"para índices negativos y el troceado ocurre en el método del objeto :meth:"
+"`__getitem__`, las subclases que sobrescriben este método necesitarán añadir "
+"explícitamente ese soporte."
 
 #: ../Doc/reference/expressions.rst:833
 msgid ""
 "A string's items are characters.  A character is not a separate data type "
 "but a string of exactly one character."
 msgstr ""
+"Los elementos de una cadena de caracteres son caracteres. Un caracter no es "
+"un tipo de datos separado sino una cadena de exactamente un caracter."
 
 #: ../Doc/reference/expressions.rst:840
 msgid "Slicings"
-msgstr ""
+msgstr "Segmentos"
 
 #: ../Doc/reference/expressions.rst:854
 msgid ""
@@ -889,6 +1300,10 @@ msgid ""
 "tuple or list).  Slicings may be used as expressions or as targets in "
 "assignment or :keyword:`del` statements.  The syntax for a slicing:"
 msgstr ""
+"Un segmento selecciona un rango de elementos en una objeto secuencia (ej., "
+"una cadena de caracteres, tupla o lista). Los segmentos pueden ser usados "
+"como expresiones o como objetivos en asignaciones o sentencias :keyword:"
+"`del`. La sintaxis para un segmento:"
 
 #: ../Doc/reference/expressions.rst:867
 msgid ""
@@ -899,6 +1314,13 @@ msgid ""
 "subscription takes priority over the interpretation as a slicing (this is "
 "the case if the slice list contains no proper slice)."
 msgstr ""
+"Hay ambigüedad en la sintaxis formal aquí: todo lo que parezca una expresión "
+"de lista también parece una segmento de lista, así que cualquier "
+"subscripción puede ser interpretada como un segmento. En lugar de complicar "
+"aún más la sintaxis, esta es desambiguada definiendo que en este caso la "
+"interpretación como una subscripción toma prioridad sobre la interpretación "
+"como un segmento (este es el caso si el segmento de lista no contiene un "
+"segmento adecuado)."
 
 #: ../Doc/reference/expressions.rst:879
 msgid ""
@@ -914,22 +1336,38 @@ msgid ""
 "upper bound and stride, respectively, substituting ``None`` for missing "
 "expressions."
 msgstr ""
+"Las semánticas para un segmento son las siguientes. El primario es indexado "
+"(usando el mismo método :meth:`__getitem__` de una subscripción normal) con "
+"una clave que se construye del segmento de lista, tal como sigue. Si el "
+"segmento de lista contiene al menos una coma, la clave es una tupla que "
+"contiene la conversión de los elementos del segmento; de otra forma, la "
+"conversión del segmento de lista solitario es la clave. La conversión de un "
+"elemento de segmento que es una expresión es esa expresión. La conversión de "
+"un segmento apropiado es un objeto segmento (ver sección :ref:`types`) cuyos "
+"atributos :attr:`~slice.start`, :attr:`~slice.stop` y :attr:`~slice.step` "
+"son los valores de las expresiones dadas como límite inferior, límite "
+"superior y paso, respectivamente, substituyendo ``None`` para las "
+"expresiones faltantes."
 
 #: ../Doc/reference/expressions.rst:903
 msgid "Calls"
-msgstr ""
+msgstr "Invocaciones"
 
 #: ../Doc/reference/expressions.rst:905
 msgid ""
 "A call calls a callable object (e.g., a :term:`function`) with a possibly "
 "empty series of :term:`arguments <argument>`:"
 msgstr ""
+"Una invocación invoca un objeto invocable (ej., una :term:`function`) con "
+"una serie posiblemente vacía de :term:`argumentos <argument>`:"
 
 #: ../Doc/reference/expressions.rst:922
 msgid ""
 "An optional trailing comma may be present after the positional and keyword "
 "arguments but does not affect the semantics."
 msgstr ""
+"Una coma final opcional puede estar presente después de los argumentos "
+"posicionales y de palabra clave pero no afecta a las semánticas."
 
 #: ../Doc/reference/expressions.rst:928
 msgid ""
@@ -940,6 +1378,13 @@ msgid ""
 "attempted.  Please refer to section :ref:`function` for the syntax of "
 "formal :term:`parameter` lists."
 msgstr ""
+"La clave primaria debe evaluar a un objeto invocable (funciones definidas "
+"por el usuario, funciones incorporadas, métodos de objetos incorporados, "
+"métodos de instancias de clases y todos los objetos que tienen un método :"
+"meth:`__call__` son invocables). Todas las expresiones de argumento son "
+"evaluadas antes de que la invocación sea intentada. Por favor, refiera a la "
+"sección :ref:`function` para la sintaxis formal de listas de :term:"
+"`parameter`."
 
 #: ../Doc/reference/expressions.rst:936
 msgid ""
@@ -962,6 +1407,26 @@ msgid ""
 "Otherwise, the list of filled slots is used as the argument list for the "
 "call."
 msgstr ""
+"Si hay argumentos de palabra clave, primero se convierten en argumentos "
+"posicionales, como se indica a continuación.  En primer lugar, se crea una "
+"lista de ranuras sin rellenar para los parámetros formales.  Si hay N "
+"argumentos posicionales, se colocan en las primeras N ranuras. A "
+"continuación, para cada argumento de palabra clave, el identificador se "
+"utiliza para determinar la ranura correspondiente (si el identificador es el "
+"mismo que el primer nombre de parámetro formal, se utiliza la primera "
+"ranura, etc.). Si la ranura ya está llena, se genera una excepción :exc:"
+"`TypeError`. De lo contrario, el valor del argumento se coloca en la ranura, "
+"llenándolo (incluso si la expresión es ``None``, esta llena la ranura). "
+"Cuando se han procesado todos los argumentos, las ranuras que aún no han "
+"sido rellenadas se rellenan con el valor predeterminado correspondiente de "
+"la definición de función. (Los valores predeterminados son calculados una "
+"vez, cuando se define la función; por lo tanto, un objeto mutable como una "
+"lista o diccionario utilizado como valor predeterminado será compartido por "
+"todas las llamadas que no especifican un valor de argumento para la ranura "
+"correspondiente; esto normalmente debe ser evitado.) Si hay ranuras sin "
+"rellenar para las que no se especifica ningún valor predeterminado, se "
+"genera una excepción :exc:`TypeError`. De lo contrario, la lista de ranuras "
+"rellenas se utiliza como la lista de argumentos para la llamada."
 
 #: ../Doc/reference/expressions.rst:956
 msgid ""
@@ -971,6 +1436,11 @@ msgid ""
 "CPython, this is the case for functions implemented in C that use :c:func:"
 "`PyArg_ParseTuple` to parse their arguments."
 msgstr ""
+"Una implementación puede proveer funciones incorporadas cuyos argumentos "
+"posicionales no tienen nombres, incluso si son \"nombrados\" a efectos de "
+"documentación y los cuales por consiguiente no pueden ser suplidos por "
+"palabras clave. En CPython, este es el caso para funciones implementadas en "
+"C que usan :c:func:`PyArg_ParseTuple` para analizar sus argumentos."
 
 #: ../Doc/reference/expressions.rst:962
 msgid ""
@@ -980,6 +1450,11 @@ msgid ""
 "parameter receives a tuple containing the excess positional arguments (or an "
 "empty tuple if there were no excess positional arguments)."
 msgstr ""
+"Si hay más argumentos posicionales que ranuras formales de parámetros, se "
+"genera una excepción :exc:`TypeError`, a no ser que un parámetro formal "
+"usando la sintaxis ``*identifier`` se encuentre presente; en este caso, ese "
+"parámetro formal recibe una tupla conteniendo los argumentos posicionales "
+"sobrantes (o una tupla vacía su no hay argumentos posicionales sobrantes)."
 
 #: ../Doc/reference/expressions.rst:968
 msgid ""
@@ -990,6 +1465,13 @@ msgid ""
 "keywords as keys and the argument values as corresponding values), or a "
 "(new) empty dictionary if there were no excess keyword arguments."
 msgstr ""
+"Si un argumento de palabra clave no corresponde a un nombre de parámetro "
+"formal, se genera una excepción :exc:`TypeError`, a no ser que un parámetro "
+"formal usando la sintaxis ``**identifier`` esté presente; en este caso, ese "
+"parámetro formal recibe un diccionario que contiene los argumentos de "
+"palabra clave sobrantes (usando las palabras clave como claves y los valores "
+"de argumento como sus valores correspondientes), o un (nuevo) diccionario "
+"vacío si no hay argumentos de palabra clave sobrantes."
 
 #: ../Doc/reference/expressions.rst:979
 msgid ""
@@ -1000,6 +1482,12 @@ msgid ""
 "this is equivalent to a call with M+4 positional arguments *x1*, *x2*, "
 "*y1*, ..., *yM*, *x3*, *x4*."
 msgstr ""
+"Si la sintaxis ``*expression`` aparece en la invocación de función, "
+"``expression`` debe evaluar a un :term:`iterable`. Elementos de esos "
+"iterables son tratados como si fueran argumentos posicionales adicionales. "
+"Para la invocación ``f(x1, x2, *y, x3, x4)``, si *y* evalúa a una secuencia "
+"*y1*, ..., *yM*, equivale a una invocación con M+4 argumentos posicionales "
+"*x1*, *x2*, *y1*, ..., *yM*, *x3*, *x4*."
 
 #: ../Doc/reference/expressions.rst:986
 msgid ""
@@ -1007,12 +1495,19 @@ msgid ""
 "*after* explicit keyword arguments, it is processed *before* the keyword "
 "arguments (and any ``**expression`` arguments -- see below).  So::"
 msgstr ""
+"Una consecuencia de esto es que aunque la sintaxis ``*expression`` puede "
+"aparecer *después* de argumentos de palabra clave explícitos, es procesada "
+"*antes* de los argumentos de palabra clave (y cualquiera de los argumentos "
+"``*expression`` -- ver abajo). Así que::"
 
 #: ../Doc/reference/expressions.rst:1002
 msgid ""
 "It is unusual for both keyword arguments and the ``*expression`` syntax to "
 "be used in the same call, so in practice this confusion does not arise."
 msgstr ""
+"Es inusual usar en la misma invocación tanto argumentos de palabra clave "
+"como la sintaxis ``*expression``, así que en la práctica no surge esta "
+"confusión."
 
 #: ../Doc/reference/expressions.rst:1008
 msgid ""
@@ -1022,12 +1517,20 @@ msgid ""
 "explicit keyword argument, or from another unpacking), a :exc:`TypeError` "
 "exception is raised."
 msgstr ""
+"Si la sintaxis ``*expression`` aparece en la invocación de función, "
+"``expression`` debe evaluar a un :term:`mapping`, los contenidos del mismo "
+"son tratados como argumentos de palabra clave adicionales. Si una palabra "
+"clave está ya presente (como un argumento de palabra clave explícito o desde "
+"otro desempaquetado), se genera una excepción :exc:`TypeError`."
 
 #: ../Doc/reference/expressions.rst:1014
 msgid ""
 "Formal parameters using the syntax ``*identifier`` or ``**identifier`` "
 "cannot be used as positional argument slots or as keyword argument names."
 msgstr ""
+"No pueden ser usados parámetros formales usando la sintaxis ``*identifier`` "
+"o ``**identifier`` como ranuras de argumentos posicionales o como nombres de "
+"argumentos de palabra clave."
 
 #: ../Doc/reference/expressions.rst:1017
 msgid ""
@@ -1035,6 +1538,11 @@ msgid ""
 "arguments may follow iterable unpackings (``*``), and keyword arguments may "
 "follow dictionary unpackings (``**``). Originally proposed by :pep:`448`."
 msgstr ""
+"Las invocaciones de función aceptan cualquier número de desempaquetados "
+"``*`` y ``**``, los argumentos posicionales pueden seguir a desempaquetados "
+"de iterable (``*``) y los argumentos de palabra clave pueden seguir a "
+"desempaquetados de diccionario (``*``). Originalmente propuesto por :pep:"
+"`448`."
 
 #: ../Doc/reference/expressions.rst:1023
 msgid ""
@@ -1042,14 +1550,17 @@ msgid ""
 "exception.  How this value is computed depends on the type of the callable "
 "object."
 msgstr ""
+"Una invocación siempre retorna algún valor, posiblemente ``None``, a no ser "
+"que genere una excepción. Cómo se calcula este valor depende del tipo del "
+"objeto invocable."
 
 #: ../Doc/reference/expressions.rst:1027
 msgid "If it is---"
-msgstr ""
+msgstr "Si es---"
 
 #: ../Doc/reference/expressions.rst:1040
 msgid "a user-defined function:"
-msgstr ""
+msgstr "una función definida por el usuario:"
 
 #: ../Doc/reference/expressions.rst:1036
 msgid ""
@@ -1059,28 +1570,35 @@ msgid ""
 "block executes a :keyword:`return` statement, this specifies the return "
 "value of the function call."
 msgstr ""
+"Se ejecuta el bloque de código para la función, pasándole la lista de "
+"argumentos. Lo primero que hace el bloque de código es enlazar los "
+"parámetros formales a los argumentos; esto es descrito en la sección :ref:"
+"`function`. Cuando el bloque de código ejecuta una sentencia :keyword:"
+"`return`, esto especifica el valor de retorno de la invocación de función."
 
 #: ../Doc/reference/expressions.rst:1054
 msgid "a built-in function or method:"
-msgstr ""
+msgstr "una función o método incorporado:"
 
 #: ../Doc/reference/expressions.rst:1053
 msgid ""
 "The result is up to the interpreter; see :ref:`built-in-funcs` for the "
 "descriptions of built-in functions and methods."
 msgstr ""
+"El resultado depende del intérprete; ver :ref:`built-in-funcs` para las "
+"descripciones de funciones y métodos incorporados."
 
 #: ../Doc/reference/expressions.rst:1061
 msgid "a class object:"
-msgstr ""
+msgstr "un objeto de clase:"
 
 #: ../Doc/reference/expressions.rst:1061
 msgid "A new instance of that class is returned."
-msgstr ""
+msgstr "Se retorna una nueva instancia de esa clase."
 
 #: ../Doc/reference/expressions.rst:1071
 msgid "a class instance method:"
-msgstr ""
+msgstr "un método de una instancia de clase:"
 
 #: ../Doc/reference/expressions.rst:1069
 msgid ""
@@ -1088,36 +1606,46 @@ msgid ""
 "that is one longer than the argument list of the call: the instance becomes "
 "the first argument."
 msgstr ""
+"Se invoca la función definida por el usuario correspondiente, con una lista "
+"de argumentos con un largo uno mayor que la lista de argumentos de la "
+"invocación: la instancia se convierte en el primer argumento."
 
 #: ../Doc/reference/expressions.rst:1080
 msgid "a class instance:"
-msgstr ""
+msgstr "una instancia de clase:"
 
 #: ../Doc/reference/expressions.rst:1078
 msgid ""
 "The class must define a :meth:`__call__` method; the effect is then the same "
 "as if that method was called."
 msgstr ""
+"La clase debe definir un método :meth:`__call__`; el efecto es entonces el "
+"mismo que si ese método fuera invocado."
 
 #: ../Doc/reference/expressions.rst:1086 ../Doc/reference/expressions.rst:1834
 msgid "Await expression"
-msgstr ""
+msgstr "Expresión await"
 
 #: ../Doc/reference/expressions.rst:1088
 msgid ""
 "Suspend the execution of :term:`coroutine` on an :term:`awaitable` object. "
 "Can only be used inside a :term:`coroutine function`."
 msgstr ""
+"Suspende la ejecución de :term:`coroutine` o un objeto :term:`awaitable`. "
+"Puede ser usado sólo dentro de una :term:`coroutine function`."
 
 #: ../Doc/reference/expressions.rst:1100
 msgid "The power operator"
-msgstr ""
+msgstr "El operador de potencia"
 
 #: ../Doc/reference/expressions.rst:1106
 msgid ""
 "The power operator binds more tightly than unary operators on its left; it "
 "binds less tightly than unary operators on its right.  The syntax is:"
 msgstr ""
+"El operador de potencia se vincula más estrechamente que los operadores "
+"unarios a su izquierda; se vincula con menos fuerza que los operadores "
+"unarios a su derecha. La sintaxis es:"
 
 #: ../Doc/reference/expressions.rst:1112
 msgid ""
@@ -1125,6 +1653,10 @@ msgid ""
 "operators are evaluated from right to left (this does not constrain the "
 "evaluation order for the operands): ``-1**2`` results in ``-1``."
 msgstr ""
+"Por lo tanto, en una secuencia sin paréntesis de operadores unarios y de "
+"potencia, los operadores son evaluados desde la derecha a la izquierda (este "
+"no se constriñe al orden de evaluación para los operandos): ``-1**2`` "
+"resulta en ``-1``."
 
 #: ../Doc/reference/expressions.rst:1116
 msgid ""
@@ -1133,6 +1665,11 @@ msgid ""
 "to the power of its right argument.  The numeric arguments are first "
 "converted to a common type, and the result is of that type."
 msgstr ""
+"El operador de potencia tiene las mismas semánticas que la función "
+"incorporada :func:`pow` cuando se invoca con dos argumentos: este produce su "
+"argumento de la izquierda elevado a la potencia de su argumento de la "
+"derecha. Los argumentos numéricos se convierten primero en un tipo común y "
+"el resultado es de ese tipo."
 
 #: ../Doc/reference/expressions.rst:1121
 msgid ""
@@ -1141,6 +1678,10 @@ msgid ""
 "float and a float result is delivered. For example, ``10**2`` returns "
 "``100``, but ``10**-2`` returns ``0.01``."
 msgstr ""
+"Para operandos int, el resultado tiene el mismo tipo que los operandos a no "
+"ser que el segundo argumento sea negativo; en ese caso, todos los argumentos "
+"son convertidos a float y se entrega un resultado float. Por ejemplo, "
+"``10**2`` retorna ``100``, pero ``10**-2`` retorna ``0.01``."
 
 #: ../Doc/reference/expressions.rst:1126
 msgid ""
@@ -1148,23 +1689,32 @@ msgid ""
 "Raising a negative number to a fractional power results in a :class:"
 "`complex` number. (In earlier versions it raised a :exc:`ValueError`.)"
 msgstr ""
+"Elevar ``0.0`` a una potencia negativa resulta en un :exc:"
+"`ZeroDivisionError`. Elevar un número negativo a una potencia fraccional "
+"resulta en un número :class:`complex`. (En versiones anteriores se genera "
+"un :exc:`ValueError`.)"
 
 #: ../Doc/reference/expressions.rst:1134
 msgid "Unary arithmetic and bitwise operations"
-msgstr ""
+msgstr "Aritmética unaria y operaciones bit a bit"
 
 #: ../Doc/reference/expressions.rst:1140
 msgid "All unary arithmetic and bitwise operations have the same priority:"
 msgstr ""
+"Toda la aritmética unaria y las operaciones bit a bit tienen la misma "
+"prioridad:"
 
 #: ../Doc/reference/expressions.rst:1151
 msgid ""
 "The unary ``-`` (minus) operator yields the negation of its numeric argument."
 msgstr ""
+"El operador unario ``-`` (menos) produce la negación de su argumento "
+"numérico."
 
 #: ../Doc/reference/expressions.rst:1158
 msgid "The unary ``+`` (plus) operator yields its numeric argument unchanged."
 msgstr ""
+"El operador unario ``+`` (más) produce su argumento numérico sin cambios."
 
 #: ../Doc/reference/expressions.rst:1164
 msgid ""
@@ -1172,16 +1722,21 @@ msgid ""
 "integer argument.  The bitwise inversion of ``x`` is defined as ``-(x+1)``.  "
 "It only applies to integral numbers."
 msgstr ""
+"El operador unario ``~`` (invertir) produce la inversión bit a bit de su "
+"argumento entero. La inversión bit a bit de ``x`` se define como ``-(x+1)``. "
+"Sólo aplica a números integrales."
 
 #: ../Doc/reference/expressions.rst:1170
 msgid ""
 "In all three cases, if the argument does not have the proper type, a :exc:"
 "`TypeError` exception is raised."
 msgstr ""
+"En todos los tres casos, si el argumento no tiene el tipo apropiado, se "
+"genera una excepción :exc:`TypeError`."
 
 #: ../Doc/reference/expressions.rst:1177
 msgid "Binary arithmetic operations"
-msgstr ""
+msgstr "Operaciones aritméticas binarias"
 
 #: ../Doc/reference/expressions.rst:1181
 msgid ""
@@ -1190,6 +1745,10 @@ msgid ""
 "Apart from the power operator, there are only two levels, one for "
 "multiplicative operators and one for additive operators:"
 msgstr ""
+"Las operaciones aritméticas binarias tienen los niveles convencionales de "
+"prioridad. Tenga en cuenta que algunas de esas operaciones también aplican a "
+"ciertos tipos no numéricos. Aparte del operador de potencia, hay sólo dos "
+"niveles, uno para operadores multiplicativos y uno para aditivos:"
 
 #: ../Doc/reference/expressions.rst:1196
 msgid ""
@@ -1200,12 +1759,20 @@ msgid ""
 "case, sequence repetition is performed; a negative repetition factor yields "
 "an empty sequence."
 msgstr ""
+"El operador ``*`` (multiplicación) produce el producto de sus argumentos. "
+"Los argumentos pueden ser ambos números, o un argumento debe ser un entero y "
+"el otro debe ser una secuencia. En el primer caso, los números se convierten "
+"a un tipo común y luego son multiplicados. En el segundo caso, se realiza "
+"una repetición de secuencia; un factor de repetición negativo produce una "
+"secuencia vacía."
 
 #: ../Doc/reference/expressions.rst:1206
 msgid ""
 "The ``@`` (at) operator is intended to be used for matrix multiplication.  "
 "No builtin Python types implement this operator."
 msgstr ""
+"El operador ``@`` (en) está destinado a ser usado para multiplicación de "
+"matrices. Ningún tipo incorporado en Python implementa este operador."
 
 #: ../Doc/reference/expressions.rst:1217
 msgid ""
@@ -1216,6 +1783,13 @@ msgid ""
 "with the 'floor' function applied to the result.  Division by zero raises "
 "the :exc:`ZeroDivisionError` exception."
 msgstr ""
+"Los operadores ``/`` (división) y ``//`` (división de redondeo) producen el "
+"cociente de sus argumentos. Los argumentos numéricos son primero convertidos "
+"a un tipo común. La división de enteros producen un número de punto "
+"flotante, mientras que la división redondeada de enteros resulta en un "
+"entero; el resultado es aquel de una división matemática con la función "
+"'floor' aplicada al resultado. Dividir entre 0 genera la excepción :exc:"
+"`ZeroDivisionError`."
 
 #: ../Doc/reference/expressions.rst:1228
 msgid ""
@@ -1228,6 +1802,14 @@ msgid ""
 "zero); the absolute value of the result is strictly smaller than the "
 "absolute value of the second operand [#]_."
 msgstr ""
+"El operador ``%`` (módulo) produce el resto de la división del primer "
+"argumento entre el segundo. Los argumentos numéricos son primero convertidos "
+"a un tipo común. Un argumento a la derecha cero genera la excepción :exc:"
+"`ZeroDivisionError`. Los argumentos pueden ser números de punto flotante, "
+"ej., ``3.14%0.7`` es igual a ``0.34`` (ya que ``3.14`` es igual a ``4*0.7 + "
+"0.34``.) El operador módulo siempre produce un resultado con el mismo signo "
+"que su segundo operando (o cero); el valor absoluto del resultado es "
+"estrictamente más pequeño que el valor absoluto del segundo operando [#]_."
 
 #: ../Doc/reference/expressions.rst:1237
 msgid ""
@@ -1236,6 +1818,10 @@ msgid ""
 "connected with the built-in function :func:`divmod`: ``divmod(x, y) == (x//"
 "y, x%y)``. [#]_."
 msgstr ""
+"Los operadores de división de redondeo y módulo están conectados por la "
+"siguiente identidad: ``x == (x//y)*y + (x%y)``. La división de redondeo y el "
+"módulo también están conectadas por la función incorporada :func:`divmod`: "
+"``divmod(x, y) == (x//y, x%y)``. [#]_."
 
 #: ../Doc/reference/expressions.rst:1242
 msgid ""
@@ -1245,6 +1831,11 @@ msgid ""
 "is described in the Python Library Reference, section :ref:`old-string-"
 "formatting`."
 msgstr ""
+"Adicionalmente a realizar la operación módulo en números, el operador ``%`` "
+"también está sobrecargado por objetos cadena de caracteres para realizar "
+"formateo de cadenas al estilo antiguo (también conocido como interpolación). "
+"La sintaxis para el formateo de cadenas está descrita en la Referencia de la "
+"Biblioteca de Python, sección :ref:`old-string-formatting`."
 
 #: ../Doc/reference/expressions.rst:1247
 msgid ""
@@ -1252,6 +1843,9 @@ msgid ""
 "function are not defined for complex numbers.  Instead, convert to a "
 "floating point number using the :func:`abs` function if appropriate."
 msgstr ""
+"El operador de división de redondeo, el operador módulo y la función :func:"
+"`divmod` no están definidas para números complejos. En su lugar, convierta a "
+"un número de punto flotante usando la función :func:`abs` si es apropiado."
 
 #: ../Doc/reference/expressions.rst:1256
 msgid ""
@@ -1260,63 +1854,85 @@ msgid ""
 "type.  In the former case, the numbers are converted to a common type and "
 "then added together. In the latter case, the sequences are concatenated."
 msgstr ""
+"El operador ``+`` (adición) produce la suma de sus argumentos. Los "
+"argumentos deben ser ambos números o ambos secuencias del mismo tipo. En el "
+"primer caso, los números son convertidos a un tipo común y luego sumados. En "
+"el segundo caso, las secuencias son concatenadas."
 
 #: ../Doc/reference/expressions.rst:1266
 msgid ""
 "The ``-`` (subtraction) operator yields the difference of its arguments.  "
 "The numeric arguments are first converted to a common type."
 msgstr ""
+"El operador ``-`` (resta) produce la diferencia de sus argumentos. Los "
+"argumentos numéricos son primero convertidos a un tipo común."
 
 #: ../Doc/reference/expressions.rst:1273
 msgid "Shifting operations"
-msgstr ""
+msgstr "Operaciones de desplazamiento"
 
 #: ../Doc/reference/expressions.rst:1280
 msgid ""
 "The shifting operations have lower priority than the arithmetic operations:"
 msgstr ""
+"Las operaciones de desplazamiento tienen menos prioridad que las operaciones "
+"aritméticas:"
 
 #: ../Doc/reference/expressions.rst:1285
 msgid ""
 "These operators accept integers as arguments.  They shift the first argument "
 "to the left or right by the number of bits given by the second argument."
 msgstr ""
+"Estos operadores aceptan enteros como argumentos. Ellos desplazan el primer "
+"argumento a la izquierda o derecha el número de dígitos dados por el segundo "
+"argumento."
 
 #: ../Doc/reference/expressions.rst:1290
 msgid ""
 "A right shift by *n* bits is defined as floor division by ``pow(2,n)``.  A "
 "left shift by *n* bits is defined as multiplication with ``pow(2,n)``."
 msgstr ""
+"Un desplazamiento de *n* bits hacia la derecha está definido como una "
+"división de redondeo entre ``pow(2,n)``. Un desplazamiento de *n* bits hacia "
+"la izquierda está definido como una multiplicación por ``pow(2,n)``."
 
 #: ../Doc/reference/expressions.rst:1297
 msgid "Binary bitwise operations"
-msgstr ""
+msgstr "Operaciones bit a bit binarias"
 
 #: ../Doc/reference/expressions.rst:1301
 msgid "Each of the three bitwise operations has a different priority level:"
 msgstr ""
+"Cada una de las tres operaciones de bits binarias tienen diferente nivel de "
+"prioridad:"
 
 #: ../Doc/reference/expressions.rst:1312
 msgid ""
 "The ``&`` operator yields the bitwise AND of its arguments, which must be "
 "integers."
 msgstr ""
+"El operador ``&`` produce el AND bit a bit de sus argumentos, los cuales "
+"deben ser enteros."
 
 #: ../Doc/reference/expressions.rst:1320
 msgid ""
 "The ``^`` operator yields the bitwise XOR (exclusive OR) of its arguments, "
 "which must be integers."
 msgstr ""
+"El operador ``^`` produce el XOR (OR exclusivo) bit a bit de sus argumentos, "
+"los cuales deben ser enteros."
 
 #: ../Doc/reference/expressions.rst:1328
 msgid ""
 "The ``|`` operator yields the bitwise (inclusive) OR of its arguments, which "
 "must be integers."
 msgstr ""
+"El operador ``|`` produce el OR (inclusivo) bit a bit de sus argumentos, los "
+"cuales deben ser enteros."
 
 #: ../Doc/reference/expressions.rst:1335
 msgid "Comparisons"
-msgstr ""
+msgstr "Comparaciones"
 
 #: ../Doc/reference/expressions.rst:1347
 msgid ""
@@ -1325,10 +1941,14 @@ msgid ""
 "unlike C, expressions like ``a < b < c`` have the interpretation that is "
 "conventional in mathematics:"
 msgstr ""
+"A diferencia de C, todas las operaciones de comparación en Python tienen la "
+"misma prioridad, la cual es menor que la de cualquier operación aritmética, "
+"de desplazamiento o bit a bit. También, a diferencia de C, expresiones como "
+"``a < b < c`` tienen la interpretación convencional en matemáticas:"
 
 #: ../Doc/reference/expressions.rst:1357
 msgid "Comparisons yield boolean values: ``True`` or ``False``."
-msgstr ""
+msgstr "Comparaciones producen valores booleanos: `` True`` o ``False``."
 
 #: ../Doc/reference/expressions.rst:1361
 msgid ""
@@ -1337,6 +1957,10 @@ msgid ""
 "both cases ``z`` is not evaluated at all when ``x < y`` is found to be "
 "false)."
 msgstr ""
+"Las comparaciones pueden ser encadenadas arbitrariamente, ej., ``x < y <= "
+"z`` es equivalente a ``x < y and y <= z``, excepto que ``y`` es evaluado "
+"sólo una vez (pero en ambos casos ``z`` no es evaluado para nada cuando ``x "
+"< y`` se encuentra que es falso)."
 
 #: ../Doc/reference/expressions.rst:1365
 msgid ""
@@ -1345,6 +1969,10 @@ msgid ""
 "z`` is equivalent to ``a op1 b and b op2 c and ... y opN z``, except that "
 "each expression is evaluated at most once."
 msgstr ""
+"Formalmente, si *a*, *b*, *c*, ..., *y*, *z* son expresiones y *op1*, "
+"*op2*, ..., *opN* son operadores de comparación, entonces ``a op1 b op2 "
+"c ... y opN z`` es equivalente a ``a op1 b and b op2 c and ... y opN z``, "
+"excepto que cada expresión es evaluada como mucho una vez."
 
 #: ../Doc/reference/expressions.rst:1370
 msgid ""
@@ -1352,16 +1980,21 @@ msgid ""
 "and *c*, so that, e.g., ``x < y > z`` is perfectly legal (though perhaps not "
 "pretty)."
 msgstr ""
+"Tenga en cuenta que ``a op1 b op2 c`` no implica ningún tipo de comparación "
+"entre *a* y *c*, por lo que, por ejemplo, ``x < y > z`` es perfectamente "
+"legal (aunque quizás no es bonito)."
 
 #: ../Doc/reference/expressions.rst:1375
 msgid "Value comparisons"
-msgstr ""
+msgstr "Comparaciones de valor"
 
 #: ../Doc/reference/expressions.rst:1377
 msgid ""
 "The operators ``<``, ``>``, ``==``, ``>=``, ``<=``, and ``!=`` compare the "
 "values of two objects.  The objects do not need to have the same type."
 msgstr ""
+"Los operadores ``<``, ``>``, ``==``, ``>=``, ``<=``, y ``!=`` comparan los "
+"valores de dos objetos. Los objetos no necesitan ser del mismo tipo."
 
 #: ../Doc/reference/expressions.rst:1380
 msgid ""
@@ -1374,6 +2007,15 @@ msgid ""
 "object is.  One can think of them as defining the value of an object "
 "indirectly, by means of their comparison implementation."
 msgstr ""
+"El capítulo :ref:`objects` afirma que los objetos tienen un valor (en "
+"adición al tipo e identidad). El valor de un objeto es una noción bastante "
+"abstracta en Python: Por ejemplo, no existe un método de acceso canónico "
+"para el valor de un objeto. Además, no se requiere que el valor de un objeto "
+"deba ser construido de una forma particular, ej. compuesto de todos sus "
+"atributos de datos. Los operadores de comparación implementan una noción "
+"particular de lo que es el valor de un objeto. Uno puede pensar en ellos "
+"definiendo el valor de un objeto indirectamente, mediante su implementación "
+"de comparación."
 
 #: ../Doc/reference/expressions.rst:1389
 msgid ""
@@ -1382,6 +2024,11 @@ msgid ""
 "customize their comparison behavior by implementing :dfn:`rich comparison "
 "methods` like :meth:`__lt__`, described in :ref:`customization`."
 msgstr ""
+"Debido a que todos los tipos son subtipos (directos o indirectos) de :class:"
+"`object`, ellos heredan el comportamiento de comparación predeterminado "
+"desde :class:`object`. Los tipos pueden personalizar su comportamiento de "
+"comparación implementando :dfn:`rich comparison methods` como :meth:"
+"`__lt__`, descritos en :ref:`customization`."
 
 #: ../Doc/reference/expressions.rst:1395
 msgid ""
@@ -1392,6 +2039,12 @@ msgid ""
 "default behavior is the desire that all objects should be reflexive (i.e. "
 "``x is y`` implies ``x == y``)."
 msgstr ""
+"El comportamiento predeterminado para comparación de igualdad (``==`` y ``!"
+"=``) se basa en la identidad de los objetos. Por lo tanto, la comparación de "
+"instancias con la misma identidad resulta en igualdad, y la comparación de "
+"igualdad de instancias con diferentes entidades resulta en desigualdad. Una "
+"motivación para este comportamiento predeterminado es el deseo de que todos "
+"los objetos sean reflexivos (ej. ``x is y`` implica ``x == y``)."
 
 #: ../Doc/reference/expressions.rst:1402
 msgid ""
@@ -1399,6 +2052,10 @@ msgid ""
 "provided; an attempt raises :exc:`TypeError`.  A motivation for this default "
 "behavior is the lack of a similar invariant as for equality."
 msgstr ""
+"No se provee un orden de comparación por defecto (``<``, ``>``, ``<=``, and "
+"``>=``); un intento genera :exc:`TypeError`. Una motivación para este "
+"comportamiento predeterminado es la falta de una invariante similar como "
+"para la igualdad."
 
 #: ../Doc/reference/expressions.rst:1406
 msgid ""
@@ -1408,12 +2065,20 @@ msgid ""
 "equality.  Such types will need to customize their comparison behavior, and "
 "in fact, a number of built-in types have done that."
 msgstr ""
+"El comportamiento de la comparación de igualdad predeterminado, que "
+"instancias con diferentes identidades siempre son desiguales, puede estar en "
+"contraste a que los tipos que necesitarán que tengan una definición sensata "
+"de valor de objeto e igualdad basada en el valor. Tales tipos necesitarán "
+"personalizar su comportamiento de comparación y, de hecho, un número de "
+"tipos incorporados lo han realizado."
 
 #: ../Doc/reference/expressions.rst:1412
 msgid ""
 "The following list describes the comparison behavior of the most important "
 "built-in types."
 msgstr ""
+"La siguiente lista describe el comportamiento de comparación de los tipos "
+"incorporados más importantes."
 
 #: ../Doc/reference/expressions.rst:1415
 msgid ""
@@ -1424,6 +2089,12 @@ msgid ""
 "involved, they compare mathematically (algorithmically) correct without loss "
 "of precision."
 msgstr ""
+"Números de tipos numéricos incorporadas (:ref:`typesnumeric`) y tipos de la "
+"biblioteca estándar :class:`fractions.Fraction` y :class:`decimal.Decimal` "
+"pueden ser comparados consigo mismos y entre sus tipos, con la restricción "
+"de que números complejos no soportan orden de comparación. Dentro de los "
+"límites de los tipos involucrados, se comparan matemáticamente "
+"(algorítmicamente) correctos sin pérdida de precisión."
 
 #: ../Doc/reference/expressions.rst:1422
 msgid ""
@@ -1434,6 +2105,12 @@ msgid ""
 "3`` and ``x == x`` are all false, while ``x != x`` is true.  This behavior "
 "is compliant with IEEE 754."
 msgstr ""
+"Los valores no-un-número ``float('NaN')`` y ``decimal.Decimal('NaN')`` son "
+"especiales. Cualquier comparación ordenada de un número a un no-un-número es "
+"falsa. Una implicación contraintuitiva es que los valores no-un-número son "
+"son iguales a sí mismos. Por ejemplo, si ``x = float('NaN')``, ``3 < x``, "
+"``x < 3`` y ``x == x`` son todos falso, mientras ``x != x`` es verdadero. "
+"Este comportamiento cumple con IEEE 754."
 
 #: ../Doc/reference/expressions.rst:1429
 msgid ""
@@ -1441,6 +2118,9 @@ msgid ""
 "comparisons for singletons should always be done with ``is`` or ``is not``, "
 "never the equality operators."
 msgstr ""
+"``None`` y ``NotImplemented`` son singletons. :PEP:`8` avisa que las "
+"comparaciones para singletons deben ser realizadas siempre con ``is`` o ``is "
+"not``, nunca los operadores de igualdad."
 
 #: ../Doc/reference/expressions.rst:1433
 msgid ""
@@ -1448,6 +2128,9 @@ msgid ""
 "compared within and across their types.  They compare lexicographically "
 "using the numeric values of their elements."
 msgstr ""
+"Las secuencias binarias (instancias de :class:`bytes` o :class:`bytearray`) "
+"pueden ser comparadas entre sí y con otros tipos. Ellas comparan "
+"lexicográficamente utilizando los valores numéricos de sus elementos."
 
 #: ../Doc/reference/expressions.rst:1437
 msgid ""
@@ -1455,10 +2138,15 @@ msgid ""
 "numerical Unicode code points (the result of the built-in function :func:"
 "`ord`) of their characters. [#]_"
 msgstr ""
+"Las cadenas de caracteres (instancias de :class:`str`) comparan "
+"lexicográficamente usando los puntos de códigos numéricos Unicode (el "
+"resultado de la función incorporada :func:`ord`) o sus caracteres. [#]_"
 
 #: ../Doc/reference/expressions.rst:1441
 msgid "Strings and binary sequences cannot be directly compared."
 msgstr ""
+"Las cadenas de caracteres y las secuencias binarias no pueden ser comparadas "
+"directamente."
 
 #: ../Doc/reference/expressions.rst:1443
 msgid ""
@@ -1468,6 +2156,11 @@ msgid ""
 "types results in inequality, and ordering comparison across these types "
 "raises :exc:`TypeError`."
 msgstr ""
+"Las secuencias (instancias de :class:`tuple`, :class:`list`, o :class:"
+"`range`) pueden ser comparadas sólo entre cada uno de sus tipos, con la "
+"restricción de que los rangos no soportan comparación de orden. Comparación "
+"de igualdad entre esos tipos resulta en desigualdad y la comparación de "
+"orden entre esos tipos genera :exc:`TypeError`."
 
 #: ../Doc/reference/expressions.rst:1449
 msgid ""
@@ -1476,11 +2169,18 @@ msgid ""
 "equal to themselves.  That lets them bypass equality tests for identical "
 "objects to improve performance and to maintain their internal invariants."
 msgstr ""
+"Las secuencias comparan lexicográficamente usando comparación de sus "
+"correspondientes elementos. Los contenedores incorporados asumen que los "
+"objetos idénticos son iguales a sí mismos. Eso les permite omitir las "
+"pruebas de igualdad para objetos idénticos para mejorar el rendimiento y "
+"mantener sus invariantes internos."
 
 #: ../Doc/reference/expressions.rst:1454
 msgid ""
 "Lexicographical comparison between built-in collections works as follows:"
 msgstr ""
+"La comparación lexicográfica entre colecciones incorporadas funciona de la "
+"siguiente forma:"
 
 #: ../Doc/reference/expressions.rst:1456
 msgid ""
@@ -1488,6 +2188,10 @@ msgid ""
 "the same length, and each pair of corresponding elements must compare equal "
 "(for example, ``[1,2] == (1,2)`` is false because the type is not the same)."
 msgstr ""
+"Para que dos colecciones sean comparadas iguales, ellas deben ser del mismo "
+"tipo, tener el mismo largo, y cada para de elementos correspondientes deben "
+"comparar iguales (por ejemplo, ``[1,2] == (1,2)`` es falso debido a que el "
+"tipo no es el mismo)."
 
 #: ../Doc/reference/expressions.rst:1461
 msgid ""
@@ -1497,6 +2201,11 @@ msgid ""
 "shorter collection is ordered first (for example, ``[1,2] < [1,2,3]`` is "
 "true)."
 msgstr ""
+"Las colecciones que soportan comparación de orden son ordenadas igual que "
+"sus primeros elementos desiguales (por ejemplo, ``[1,2,x] <= [1,2,y]`` tiene "
+"el mismo valor que ``x <= y``). Si un elemento correspondiente no existe, la "
+"colección más corta es ordenada primero (por ejemplo, ``[1,2] < [1,2,3]`` es "
+"verdadero)."
 
 #: ../Doc/reference/expressions.rst:1467
 msgid ""
@@ -1504,17 +2213,24 @@ msgid ""
 "equal `(key, value)` pairs. Equality comparison of the keys and values "
 "enforces reflexivity."
 msgstr ""
+"Los mapeos (instancias de :class:`dict`) comparan igual si y sólo si tienen "
+"pares `(clave, valor)` iguales. La comparación de igualdad de claves y "
+"valores refuerza la reflexibilidad."
 
 #: ../Doc/reference/expressions.rst:1471
 msgid ""
 "Order comparisons (``<``, ``>``, ``<=``, and ``>=``) raise :exc:`TypeError`."
 msgstr ""
+"Comparaciones de orden (``<``, ``>``, ``<=``, and ``>=``) generan :exc:"
+"`TypeError`."
 
 #: ../Doc/reference/expressions.rst:1473
 msgid ""
 "Sets (instances of :class:`set` or :class:`frozenset`) can be compared "
 "within and across their types."
 msgstr ""
+"Conjuntos (instancias de :class:`set` o :class:`frozenset`) pueden ser "
+"comparadas entre sí y entre sus tipos."
 
 #: ../Doc/reference/expressions.rst:1476
 msgid ""
@@ -1526,86 +2242,107 @@ msgid ""
 "func:`max`, and :func:`sorted` produce undefined results given a list of "
 "sets as inputs)."
 msgstr ""
+"Ellas definen operadores de comparación de orden con la intención de "
+"comprobar subconjuntos y superconjuntos. Tales relaciones no definen "
+"ordenaciones completas (por ejemplo, los dos conjuntos ``{1,2}`` y ``{2,3}`` "
+"no son iguales, ni subconjuntos ni superconjuntos uno de otro). Acordemente, "
+"los conjuntos no son argumentos apropiados para funciones que dependen de "
+"ordenación completa (por ejemplo, :func:`min`, :func:`max` y :func:`sorted` "
+"producen resultados indefinidos dados una lista de conjuntos como entradas)."
 
 #: ../Doc/reference/expressions.rst:1484
 msgid "Comparison of sets enforces reflexivity of its elements."
 msgstr ""
+"La comparación de conjuntos refuerza la reflexibilidad de sus elementos."
 
 #: ../Doc/reference/expressions.rst:1486
 msgid ""
 "Most other built-in types have no comparison methods implemented, so they "
 "inherit the default comparison behavior."
 msgstr ""
+"La mayoría de los otros tipos incorporados no tienen métodos de comparación "
+"implementados, por lo que ellos heredan el comportamiento de comparación "
+"predeterminado."
 
 #: ../Doc/reference/expressions.rst:1489
 msgid ""
 "User-defined classes that customize their comparison behavior should follow "
 "some consistency rules, if possible:"
 msgstr ""
+"Las clases definidas por el usuario que personalizan su comportamiento de "
+"comparación deben seguir algunas reglas de consistencia, si es posible:"
 
 #: ../Doc/reference/expressions.rst:1492
 msgid ""
 "Equality comparison should be reflexive. In other words, identical objects "
 "should compare equal:"
 msgstr ""
+"La comparación de igualdad debe ser reflexiva. En otras palabras, los "
+"objetos idénticos deben comparar iguales:"
 
 #: ../Doc/reference/expressions.rst:1495
 msgid "``x is y`` implies ``x == y``"
-msgstr ""
+msgstr "``x is y`` implica ``x == y``"
 
 #: ../Doc/reference/expressions.rst:1497
 msgid ""
 "Comparison should be symmetric. In other words, the following expressions "
 "should have the same result:"
 msgstr ""
+"La comparación debe ser simétrica. En otras palabras, las siguientes "
+"expresiones deben tener el mismo resultado:"
 
 #: ../Doc/reference/expressions.rst:1500
 msgid "``x == y`` and ``y == x``"
-msgstr ""
+msgstr "``x == y`` y ``y == x``"
 
 #: ../Doc/reference/expressions.rst:1502
 msgid "``x != y`` and ``y != x``"
-msgstr ""
+msgstr "``x != y`` y ``y != x``"
 
 #: ../Doc/reference/expressions.rst:1504
 msgid "``x < y`` and ``y > x``"
-msgstr ""
+msgstr "``x < y`` y ``y > x``"
 
 #: ../Doc/reference/expressions.rst:1506
 msgid "``x <= y`` and ``y >= x``"
-msgstr ""
+msgstr "``x <= y`` y ``y >= x``"
 
 #: ../Doc/reference/expressions.rst:1508
 msgid ""
 "Comparison should be transitive. The following (non-exhaustive) examples "
 "illustrate that:"
 msgstr ""
+"La comparación debe ser transitiva. Los siguientes ejemplos (no exhaustivos) "
+"ilustran esto:"
 
 #: ../Doc/reference/expressions.rst:1511
 msgid "``x > y and y > z`` implies ``x > z``"
-msgstr ""
+msgstr "``x > y and y > z`` implica ``x > z``"
 
 #: ../Doc/reference/expressions.rst:1513
 msgid "``x < y and y <= z`` implies ``x < z``"
-msgstr ""
+msgstr "``x < y and y <= z`` implica ``x < z``"
 
 #: ../Doc/reference/expressions.rst:1515
 msgid ""
 "Inverse comparison should result in the boolean negation. In other words, "
 "the following expressions should have the same result:"
 msgstr ""
+"La comparación inversa debe resultar en la negación booleana. En otras "
+"palabras, las siguientes expresiones deben tener el mismo resultado:"
 
 #: ../Doc/reference/expressions.rst:1518
 msgid "``x == y`` and ``not x != y``"
-msgstr ""
+msgstr "``x == y`` y ``not x != y``"
 
 #: ../Doc/reference/expressions.rst:1520
 msgid "``x < y`` and ``not x >= y`` (for total ordering)"
-msgstr ""
+msgstr "``x < y`` y ``not x >= y`` (para ordenación completa)"
 
 #: ../Doc/reference/expressions.rst:1522
 msgid "``x > y`` and ``not x <= y`` (for total ordering)"
-msgstr ""
+msgstr "``x > y`` y ``not x <= y`` (para ordenación completa)"
 
 #: ../Doc/reference/expressions.rst:1524
 msgid ""
@@ -1613,22 +2350,30 @@ msgid ""
 "sequences, but not to sets or mappings). See also the :func:`~functools."
 "total_ordering` decorator."
 msgstr ""
+"Las últimas dos expresiones aplican a colecciones completamente ordenadas "
+"(ej. a secuencias, pero no a conjuntos o mapeos). Vea también el decorador :"
+"func:`~functools.total_ordering`."
 
 #: ../Doc/reference/expressions.rst:1528
 msgid ""
 "The :func:`hash` result should be consistent with equality. Objects that are "
 "equal should either have the same hash value, or be marked as unhashable."
 msgstr ""
+"La función :func:`hash` debe ser consistente con la igualdad. Los objetos "
+"que son iguales deben tener el mismo valor de hash o ser marcados como "
+"inhashables."
 
 #: ../Doc/reference/expressions.rst:1532
 msgid ""
 "Python does not enforce these consistency rules. In fact, the not-a-number "
 "values are an example for not following these rules."
 msgstr ""
+"Python no fuerza a cumplir esas reglas de coherencia. De hecho, los valores "
+"no-un-número son u ejemplo para no seguir esas reglas."
 
 #: ../Doc/reference/expressions.rst:1541
 msgid "Membership test operations"
-msgstr ""
+msgstr "Operaciones de prueba de membresía"
 
 #: ../Doc/reference/expressions.rst:1543
 msgid ""
@@ -1640,6 +2385,14 @@ msgid ""
 "types such as list, tuple, set, frozenset, dict, or collections.deque, the "
 "expression ``x in y`` is equivalent to ``any(x is e or x == e for e in y)``."
 msgstr ""
+"Los operadores :keyword:`in` y :keyword:`not in` comprueban membresía. ``x "
+"in s`` evalúa a ``True`` si *x* es un miembro de *s* y ``False`` en caso "
+"contrario. ``x not in s`` retorna la negación de ``x in s``. Todas las "
+"secuencias incorporadas y tipos conjuntos soportan esto, así como "
+"diccionarios, para los cuales :keyword:`!in` comprueba si un diccionario "
+"tiene una clave dada. Para tipos contenedores como list, tuple, set, "
+"frozenset, dict o collections.deque, la expresión ``x in y`` es equivalente "
+"a ``any(x is e or x == e for e in y)``."
 
 #: ../Doc/reference/expressions.rst:1551
 msgid ""
@@ -1648,6 +2401,11 @@ msgid ""
 "strings are always considered to be a substring of any other string, so ``"
 "\"\" in \"abc\"`` will return ``True``."
 msgstr ""
+"Para los tipos cadenas de caracteres y bytes, ``x in y`` es ``True`` si y "
+"sólo si *x* es una subcadena de *y*. Una comprobación equivalente es ``y."
+"find(x) != -1``. Las cadenas de caracteres vacías siempre son consideradas "
+"como subcadenas de cualquier otra cadena de caracteres, por lo que ``\"\" in "
+"\"abc\"`` retornará ``True``."
 
 #: ../Doc/reference/expressions.rst:1556
 msgid ""
@@ -1655,6 +2413,9 @@ msgid ""
 "in y`` returns ``True`` if ``y.__contains__(x)`` returns a true value, and "
 "``False`` otherwise."
 msgstr ""
+"Para clases definidas por el usuario las cuales definen el método :meth:"
+"`__contains__`, ``x in y`` retorna ``True`` si ``y.__contains__(x)`` retorna "
+"un valor verdadero y ``False`` si no."
 
 #: ../Doc/reference/expressions.rst:1560
 msgid ""
@@ -1664,6 +2425,12 @@ msgid ""
 "iterating over ``y``. If an exception is raised during the iteration, it is "
 "as if :keyword:`in` raised that exception."
 msgstr ""
+"Para clases definidas por el usuario las cuales no definen :meth:"
+"`__contains__` pero definen :meth:`__iter__`, ``x in y`` es ``True`` si "
+"algún valor ``z``, para el cual la expresión ``x is z or x == z`` es "
+"verdadera, es producido iterando sobre ``y``. Si una excepción es generada "
+"durante la iteración, es como si :keyword:`in` hubiera generado esa "
+"excepción."
 
 #: ../Doc/reference/expressions.rst:1566
 msgid ""
@@ -1673,16 +2440,24 @@ msgid ""
 "index raises the :exc:`IndexError` exception.  (If any other exception is "
 "raised, it is as if :keyword:`in` raised that exception)."
 msgstr ""
+"Por último, se intenta el protocolo de iteración al estilo antiguo: si una "
+"clase define :meth:`__getitem__`, ``x in y`` es ``True`` si y sólo si hay un "
+"índice entero no negativo *i* tal que ``x is y[i] or x == y[i]`` y ningún "
+"entero menor genera la excepción :exc:`IndexError`. (Si cualquier otra "
+"excepción es generada, es como si :keyword:`in` hubiera generado esa "
+"excepción)."
 
 #: ../Doc/reference/expressions.rst:1578
 msgid ""
 "The operator :keyword:`not in` is defined to have the inverse truth value "
 "of :keyword:`in`."
 msgstr ""
+"El operador :keyword:`not in` es definido para tener el valor de veracidad "
+"inverso de :keyword:`in`."
 
 #: ../Doc/reference/expressions.rst:1591
 msgid "Identity comparisons"
-msgstr ""
+msgstr "Comparaciones de identidad"
 
 #: ../Doc/reference/expressions.rst:1593
 msgid ""
@@ -1691,10 +2466,14 @@ msgid ""
 "object.  An Object's identity is determined using the :meth:`id` function.  "
 "``x is not y`` yields the inverse truth value. [#]_"
 msgstr ""
+"Los operadores :keyword:`is` y :keyword:`is not` comprueban la identidad de "
+"un objeto. ``x is y`` es verdadero si y sólo si *x* e *y* son el mismo "
+"objeto. La identidad de un Objeto se determina usando la función :meth:`id`. "
+"``x is not y`` produce el valor de veracidad inverso. [#]_"
 
 #: ../Doc/reference/expressions.rst:1605
 msgid "Boolean operations"
-msgstr ""
+msgstr "Operaciones booleanas"
 
 #: ../Doc/reference/expressions.rst:1616
 msgid ""
@@ -1706,24 +2485,38 @@ msgid ""
 "objects can customize their truth value by providing a :meth:`__bool__` "
 "method."
 msgstr ""
+"En el contexto de las operaciones booleanas y también cuando sentencias de "
+"control de flujo usan expresiones, los siguientes valores se interpretan "
+"como falsos: ``False``, ``None``, ceros numéricos de todos los tipos y "
+"cadenas de caracteres y contenedores vacíos (incluyendo cadenas de "
+"caracteres, tuplas, diccionarios, conjuntos y conjuntos congelados). Todos "
+"los otros valores son interpretados como verdaderos. Los objetos definidos "
+"por el usuario pueden personalizar su valor de veracidad proveyendo un "
+"método :meth:`__bool__`."
 
 #: ../Doc/reference/expressions.rst:1625
 msgid ""
 "The operator :keyword:`not` yields ``True`` if its argument is false, "
 "``False`` otherwise."
 msgstr ""
+"El operador :keyword:`not` produce ``True`` si su argumento es falso, "
+"``False`` si no."
 
 #: ../Doc/reference/expressions.rst:1630
 msgid ""
 "The expression ``x and y`` first evaluates *x*; if *x* is false, its value "
 "is returned; otherwise, *y* is evaluated and the resulting value is returned."
 msgstr ""
+"La expresión ``x and y`` primero evalúa *x*; si *x* es falso, se retorna su "
+"valor; de otra forma, *y* es evaluado y se retorna el valor resultante."
 
 #: ../Doc/reference/expressions.rst:1635
 msgid ""
 "The expression ``x or y`` first evaluates *x*; if *x* is true, its value is "
 "returned; otherwise, *y* is evaluated and the resulting value is returned."
 msgstr ""
+"La expresión ``x or y`` primero evalúa *x*; si *x* es verdadero, se retorna "
+"su valor; de otra forma, *y* es evaluado y se retorna el valor resultante."
 
 #: ../Doc/reference/expressions.rst:1638
 msgid ""
@@ -1735,24 +2528,34 @@ msgid ""
 "create a new value, it returns a boolean value regardless of the type of its "
 "argument (for example, ``not 'foo'`` produces ``False`` rather than ``''``.)"
 msgstr ""
+"Tenga en cuenta que ni :keyword:`and` ni :keyword:`or` restringen el valor y "
+"el tipo que retornan a ``False`` y ``True``, sino retornan el último "
+"argumento evaluado. Esto es útil a veces, ej., si ``s`` es una cadena de "
+"caracteres que debe ser remplazada por un valor predeterminado si está "
+"vacía, la expresión ``s or 'foo'`` produce el valor deseado. Debido a que :"
+"keyword:`not` tiene que crear un nuevo valor, retorna un valor booleano "
+"indiferentemente del tipo de su argumento (por ejemplo, ``not 'foo'`` "
+"produce ``False`` en lugar de ``''``.)"
 
 #: ../Doc/reference/expressions.rst:1648
 msgid "Assignment expressions"
-msgstr ""
+msgstr "Expresiones de asignación"
 
 #: ../Doc/reference/expressions.rst:1655
 msgid "See :pep:`572` for more details about assignment expressions."
-msgstr ""
+msgstr "Vea :pep:`572` para más detalles sobre las expresiones de asignación."
 
 #: ../Doc/reference/expressions.rst:1661
 msgid "Conditional expressions"
-msgstr ""
+msgstr "Expresiones condicionales"
 
 #: ../Doc/reference/expressions.rst:1674
 msgid ""
 "Conditional expressions (sometimes called a \"ternary operator\") have the "
 "lowest priority of all Python operations."
 msgstr ""
+"Las expresiones condicionales (a veces denominadas un \"operador ternario\") "
+"tienen la prioridad más baja que todas las operaciones de Python."
 
 #: ../Doc/reference/expressions.rst:1677
 msgid ""
@@ -1760,14 +2563,17 @@ msgid ""
 "than *x*. If *C* is true, *x* is evaluated and its value is returned; "
 "otherwise, *y* is evaluated and its value is returned."
 msgstr ""
+"La expresión ``x if C else y`` primero evalúa la condición, *C* en lugar de "
+"*x*. Si *C* es verdadero, *x* es evaluado y se retorna su valor; en caso "
+"contrario, *y* es evaluado y se retorna su valor."
 
 #: ../Doc/reference/expressions.rst:1681
 msgid "See :pep:`308` for more details about conditional expressions."
-msgstr ""
+msgstr "Vea :pep:`308` para más detalles sobre expresiones condicionales."
 
 #: ../Doc/reference/expressions.rst:1688
 msgid "Lambdas"
-msgstr ""
+msgstr "Lambdas"
 
 #: ../Doc/reference/expressions.rst:1700
 msgid ""
@@ -1776,6 +2582,10 @@ msgid ""
 "a function object.  The unnamed object behaves like a function object "
 "defined with:"
 msgstr ""
+"Las expresiones lambda (a veces denominadas formas lambda) son usadas para "
+"crear funciones anónimas. La expresión ``lambda parameters: expression`` "
+"produce un objeto de función. El objeto sin nombre se comporta como un "
+"objeto función con:"
 
 #: ../Doc/reference/expressions.rst:1709
 msgid ""
@@ -1783,10 +2593,13 @@ msgid ""
 "functions created with lambda expressions cannot contain statements or "
 "annotations."
 msgstr ""
+"Vea la sección :ref:`function` para la sintaxis de listas de parámetros. "
+"Tenga en cuenta que las funciones creadas con expresiones lambda no pueden "
+"contener sentencias ni anotaciones."
 
 #: ../Doc/reference/expressions.rst:1717
 msgid "Expression lists"
-msgstr ""
+msgstr "Listas de expresiones"
 
 #: ../Doc/reference/expressions.rst:1731
 msgid ""
@@ -1794,6 +2607,10 @@ msgid ""
 "least one comma yields a tuple.  The length of the tuple is the number of "
 "expressions in the list.  The expressions are evaluated from left to right."
 msgstr ""
+"Excepto cuando son parte de un despliegue de lista o conjunto, una lista de "
+"expresión conteniendo al menos una coma produce una tupla. El largo de la "
+"tupla es el número de expresiones en la lista. Las expresiones son evaluadas "
+"de izquierda a derecha."
 
 #: ../Doc/reference/expressions.rst:1740
 msgid ""
@@ -1802,11 +2619,17 @@ msgid ""
 "which are included in the new tuple, list, or set, at the site of the "
 "unpacking."
 msgstr ""
+"Un asterisco ``*`` denota :dfn:`iterable unpacking`. Su operando deben ser "
+"un :term:`iterable`. El iterable es expandido en una secuencia de elementos, "
+"los cuales son incluidos en la nueva tupla, lista o conjunto en el lugar del "
+"desempaquetado."
 
 #: ../Doc/reference/expressions.rst:1745
 msgid ""
 "Iterable unpacking in expression lists, originally proposed by :pep:`448`."
 msgstr ""
+"Desempaquetado iterable en listas de expresiones, originalmente propuesto "
+"por :pep:`488`."
 
 #: ../Doc/reference/expressions.rst:1750
 msgid ""
@@ -1816,10 +2639,15 @@ msgid ""
 "of that expression. (To create an empty tuple, use an empty pair of "
 "parentheses: ``()``.)"
 msgstr ""
+"La coma final sólo es requerida para crear una tupla única (también "
+"denominada un *singleton*); es opcional en todos los otros casos. Una única "
+"expresión sin una coma final no crea una tupla, si no produce el valor de "
+"esa expresion. (Para crear una tupla vacía, usa un par de paréntesis vacío: "
+"``()``.)"
 
 #: ../Doc/reference/expressions.rst:1760
 msgid "Evaluation order"
-msgstr ""
+msgstr "Orden de evaluación"
 
 #: ../Doc/reference/expressions.rst:1764
 msgid ""
@@ -1827,16 +2655,21 @@ msgid ""
 "evaluating an assignment, the right-hand side is evaluated before the left-"
 "hand side."
 msgstr ""
+"Python evalúa las expresiones de izquierda a derecha. Note que mientras se "
+"evalúa una asignación, la parte derecha es evaluada antes que la parte "
+"izquierda."
 
 #: ../Doc/reference/expressions.rst:1767
 msgid ""
 "In the following lines, expressions will be evaluated in the arithmetic "
 "order of their suffixes::"
 msgstr ""
+"En las siguientes líneas, las expresiones serán evaluadas en el orden "
+"aritmético de sus sufijos::"
 
 #: ../Doc/reference/expressions.rst:1781
 msgid "Operator precedence"
-msgstr ""
+msgstr "Prioridad de operador"
 
 #: ../Doc/reference/expressions.rst:1786
 msgid ""
@@ -1846,6 +2679,12 @@ msgid ""
 "explicitly given, operators are binary.  Operators in the same box group "
 "left to right (except for exponentiation, which groups from right to left)."
 msgstr ""
+"La siguiente tabla resume la prioridad de operador en Python, desde la "
+"prioridad más baja (menos vinculante) a la prioridad más alta (más "
+"vinculante). Operadores en la misma caja tienen la misma prioridad. A no ser "
+"que la sintaxis sea dada explícitamente, los operadores son binarios. Los "
+"operadores en la misma caja, de izquierda a derecha (excepto para "
+"exponenciación, cuyos grupos de derecha a izquierda)."
 
 #: ../Doc/reference/expressions.rst:1792
 msgid ""
@@ -1853,168 +2692,178 @@ msgid ""
 "same precedence and have a left-to-right chaining feature as described in "
 "the :ref:`comparisons` section."
 msgstr ""
+"Tenga en cuenta que las comparaciones, comprobaciones de membresía y las "
+"comprobaciones de identidad tienen la misma prioridad y una característica "
+"de encadenado de izquierda a derecha como son descritas en la sección :ref:"
+"`comparisons`."
 
 #: ../Doc/reference/expressions.rst:1798
 msgid "Operator"
-msgstr ""
+msgstr "Operador"
 
 #: ../Doc/reference/expressions.rst:1798
 msgid "Description"
-msgstr ""
+msgstr "Descripción"
 
 #: ../Doc/reference/expressions.rst:1800
 msgid "``:=``"
-msgstr ""
+msgstr "``:=``"
 
 #: ../Doc/reference/expressions.rst:1800
 msgid "Assignment expression"
-msgstr ""
+msgstr "Expresión de asignación"
 
 #: ../Doc/reference/expressions.rst:1802
 msgid ":keyword:`lambda`"
-msgstr ""
+msgstr ":keyword:`lambda`"
 
 #: ../Doc/reference/expressions.rst:1802
 msgid "Lambda expression"
-msgstr ""
+msgstr "Expresión lambda"
 
 #: ../Doc/reference/expressions.rst:1804
 msgid ":keyword:`if <if_expr>` -- :keyword:`!else`"
-msgstr ""
+msgstr ":keyword:`if <if_expr>` -- :keyword:`!else`"
 
 #: ../Doc/reference/expressions.rst:1804
 msgid "Conditional expression"
-msgstr ""
+msgstr "Expresión condicional"
 
 #: ../Doc/reference/expressions.rst:1806
 msgid ":keyword:`or`"
-msgstr ""
+msgstr ":keyword:`or`"
 
 #: ../Doc/reference/expressions.rst:1806
 msgid "Boolean OR"
-msgstr ""
+msgstr "Booleano OR"
 
 #: ../Doc/reference/expressions.rst:1808
 msgid ":keyword:`and`"
-msgstr ""
+msgstr ":keyword:`and`"
 
 #: ../Doc/reference/expressions.rst:1808
 msgid "Boolean AND"
-msgstr ""
+msgstr "Booleano AND"
 
 #: ../Doc/reference/expressions.rst:1810
 msgid ":keyword:`not` ``x``"
-msgstr ""
+msgstr ":keyword:`not` ``x``"
 
 #: ../Doc/reference/expressions.rst:1810
 msgid "Boolean NOT"
-msgstr ""
+msgstr "Booleano NOT"
 
 #: ../Doc/reference/expressions.rst:1812
 msgid ""
 ":keyword:`in`, :keyword:`not in`, :keyword:`is`, :keyword:`is not`, ``<``, "
 "``<=``, ``>``, ``>=``, ``!=``, ``==``"
 msgstr ""
+":keyword:`in`, :keyword:`not in`, :keyword:`is`, :keyword:`is not`, ``<``, "
+"``<=``, ``>``, ``>=``, ``!=``, ``==``"
 
 #: ../Doc/reference/expressions.rst:1812
 msgid "Comparisons, including membership tests and identity tests"
-msgstr ""
+msgstr "Comparaciones, incluyendo comprobaciones de membresía y de identidad"
 
 #: ../Doc/reference/expressions.rst:1816
 msgid "``|``"
-msgstr ""
+msgstr "``|``"
 
 #: ../Doc/reference/expressions.rst:1816
 msgid "Bitwise OR"
-msgstr ""
+msgstr "OR bit a bit"
 
 #: ../Doc/reference/expressions.rst:1818
 msgid "``^``"
-msgstr ""
+msgstr "``^``"
 
 #: ../Doc/reference/expressions.rst:1818
 msgid "Bitwise XOR"
-msgstr ""
+msgstr "XOR bit a bit"
 
 #: ../Doc/reference/expressions.rst:1820
 msgid "``&``"
-msgstr ""
+msgstr "``&``"
 
 #: ../Doc/reference/expressions.rst:1820
 msgid "Bitwise AND"
-msgstr ""
+msgstr "AND bit a bit"
 
 #: ../Doc/reference/expressions.rst:1822
 msgid "``<<``, ``>>``"
-msgstr ""
+msgstr "``<<``, ``>>``"
 
 #: ../Doc/reference/expressions.rst:1822
 msgid "Shifts"
-msgstr ""
+msgstr "Desplazamientos"
 
 #: ../Doc/reference/expressions.rst:1824
 msgid "``+``, ``-``"
-msgstr ""
+msgstr "``+``, ``-``"
 
 #: ../Doc/reference/expressions.rst:1824
 msgid "Addition and subtraction"
-msgstr ""
+msgstr "Adición y sustracción"
 
 #: ../Doc/reference/expressions.rst:1826
 msgid "``*``, ``@``, ``/``, ``//``, ``%``"
-msgstr ""
+msgstr "``*``, ``@``, ``/``, ``//``, ``%``"
 
 #: ../Doc/reference/expressions.rst:1826
 msgid ""
 "Multiplication, matrix multiplication, division, floor division, remainder "
 "[#]_"
 msgstr ""
+"Multiplicación, multiplicación de matrices, división, división de redondeo, "
+"resto [#]_"
 
 #: ../Doc/reference/expressions.rst:1830
 msgid "``+x``, ``-x``, ``~x``"
-msgstr ""
+msgstr "``+x``, ``-x``, ``~x``"
 
 #: ../Doc/reference/expressions.rst:1830
 msgid "Positive, negative, bitwise NOT"
-msgstr ""
+msgstr "NOT positivo, negativo, bit a bit"
 
 #: ../Doc/reference/expressions.rst:1832
 msgid "``**``"
-msgstr ""
+msgstr "``**``"
 
 #: ../Doc/reference/expressions.rst:1832
 msgid "Exponentiation [#]_"
-msgstr ""
+msgstr "Exponenciación [#]_"
 
 #: ../Doc/reference/expressions.rst:1834
 msgid ":keyword:`await` ``x``"
-msgstr ""
+msgstr ":keyword:`await` ``x``"
 
 #: ../Doc/reference/expressions.rst:1836
 msgid "``x[index]``, ``x[index:index]``, ``x(arguments...)``, ``x.attribute``"
-msgstr ""
+msgstr "``x[index]``, ``x[index:index]``, ``x(arguments...)``, ``x.attribute``"
 
 #: ../Doc/reference/expressions.rst:1836
 msgid "Subscription, slicing, call, attribute reference"
-msgstr ""
+msgstr "Subscripción, segmentación, invocación, referencia de atributo"
 
 #: ../Doc/reference/expressions.rst:1839
 msgid "``(expressions...)``,"
-msgstr ""
+msgstr "``(expressions...)``,"
 
 #: ../Doc/reference/expressions.rst:1841
 msgid "``[expressions...]``, ``{key: value...}``, ``{expressions...}``"
-msgstr ""
+msgstr "``[expressions...]``, ``{key: value...}``, ``{expressions...}``"
 
 #: ../Doc/reference/expressions.rst:1839
 msgid ""
 "Binding or parenthesized expression, list display, dictionary display, set "
 "display"
 msgstr ""
+"Expresión de enlace o entre paréntesis, despliegues de lista, diccionario y "
+"conjunto"
 
 #: ../Doc/reference/expressions.rst:1848
 msgid "Footnotes"
-msgstr ""
+msgstr "Notas al pie"
 
 #: ../Doc/reference/expressions.rst:1849
 #, python-format
@@ -2028,6 +2877,15 @@ msgid ""
 "the first argument instead, and so returns ``-1e-100`` in this case. Which "
 "approach is more appropriate depends on the application."
 msgstr ""
+"Mientras ``abs(x%y) < abs(y)`` es matemáticamente verdadero, para números de "
+"punto flotante puede no ser verdadero numéricamente debido al redondeo. Por "
+"ejemplo, y asumiendo una plataforma en la cual un número de punto flotante "
+"de Python es un número de doble precisión IEEE 754, a fin de que ``-1e-100 % "
+"1e100`` tenga el mismo signo que ``1e100``, el resultado calculado es "
+"``-1e-100 + 1e100``, el cual es numéricamente exactamente igual a ``1e100``. "
+"La función :func:`math.fmod` retorna un resultado cuyo signo concuerda con "
+"el signo del primer argumento en su lugar, y por ello retorna ``-1e-100`` en "
+"este caso. La aproximación más apropiada depende de su aplicación."
 
 #: ../Doc/reference/expressions.rst:1858
 msgid ""
@@ -2036,6 +2894,10 @@ msgid ""
 "Python returns the latter result, in order to preserve that ``divmod(x,y)[0] "
 "* y + x % y`` be very close to ``x``."
 msgstr ""
+"Si x está muy cerca de un entero exacto múltiple de y, es posible para ``x//"
+"y`` que sea uno mayor que ``(x-x%y)//y`` debido al redondeo. En tales casos, "
+"Python retorna el último resultado, a fin de preservar que ``divmod(x,y)[0] "
+"* y + x % y`` sea muy cercano a ``x``."
 
 #: ../Doc/reference/expressions.rst:1863
 msgid ""
@@ -2050,6 +2912,17 @@ msgid ""
 "LETTER C), followed by a :dfn:`combining character` at code position U+0327 "
 "(COMBINING CEDILLA)."
 msgstr ""
+"El estándar Unicode distingue entre :dfn:`code points` (ej. U+0041) y :dfn:"
+"`abstract characters` (ej. \"LETRA MAYÚSCULA LATINA A\"). Mientras la "
+"mayoría de caracteres abstractos en Unicode sólo son representados usando un "
+"punto de código, hay un número de caracteres abstractos que pueden "
+"adicionalmente ser representados usado una secuencia de más de un punto de "
+"código. Por ejemplo, el caracter abstracto \"LETRA MAYÚSCULA C LATINA CON "
+"CEDILLA\" puede ser representado como un único :dfn:`precomposed character` "
+"en la posición de código U+00C7, o como una secuencia de un :dfn:`base "
+"character` en la posición de código U+0043 (LETRA MAYÚSCULA C LATINA), "
+"seguida de un :dfn:`combining character` en la posición de código U+0327 "
+"(CEDILLA COMBINADA)."
 
 #: ../Doc/reference/expressions.rst:1874
 msgid ""
@@ -2058,12 +2931,19 @@ msgid ""
 "== \"\\u0043\\u0327\"`` is ``False``, even though both strings represent the "
 "same abstract character \"LATIN CAPITAL LETTER C WITH CEDILLA\"."
 msgstr ""
+"Los operadores de comparación comparan en cadenas de caracteres al nivel de "
+"puntos de código Unicode. Esto puede ser contraintuitivo para humanos. Por "
+"ejemplo, ``\"\\u00C7\" == \"\\u0043\\u0327\"`` es ``False``, incluso aunque "
+"ambas cadenas presenten el mismo caracter abstracto \"LETRA MAYÚSCULA C "
+"LATINA CON CEDILLA\"."
 
 #: ../Doc/reference/expressions.rst:1879
 msgid ""
 "To compare strings at the level of abstract characters (that is, in a way "
 "intuitive to humans), use :func:`unicodedata.normalize`."
 msgstr ""
+"Para comparar cadenas al nivel de caracteres abstractos (esto es, de una "
+"forma intuitiva para humanos), usa :func:`unicodedata.normalize`."
 
 #: ../Doc/reference/expressions.rst:1882
 msgid ""
@@ -2072,15 +2952,25 @@ msgid ""
 "the :keyword:`is` operator, like those involving comparisons between "
 "instance methods, or constants.  Check their documentation for more info."
 msgstr ""
+"Debido a la recolección automática de basura, listas libres y a la "
+"naturaleza dinámica de los descriptores, puede notar un comportamiento "
+"aparentemente inusual en ciertos usos del operador :keyword:`is`, como "
+"aquellos involucrando comparaciones entre métodos de instancia, o "
+"constantes. Compruebe su documentación para más información."
 
 #: ../Doc/reference/expressions.rst:1887
 msgid ""
 "The ``%`` operator is also used for string formatting; the same precedence "
 "applies."
 msgstr ""
+"El operador ``%`` también es usado para formateo de cadenas; aplica la misma "
+"prioridad."
 
 #: ../Doc/reference/expressions.rst:1890
 msgid ""
 "The power operator ``**`` binds less tightly than an arithmetic or bitwise "
 "unary operator on its right, that is, ``2**-1`` is ``0.5``."
 msgstr ""
+"El operador de potencia ``**`` vincula con menos fuerza que un operador "
+"unario aritmético uno bit a bit en su derecha, esto significa que ``2**-1`` "
+"is ``0.5``."


### PR DESCRIPTION
Closes #324

### Aclaraciones

- He traducido ["display"](https://docs.python.org/3/reference/expressions.html#displays-for-lists-sets-and-dictionaries) como "despliegue". Me parece que es el término más adecuado en el contexto, pero estoy seguro que podría estar abierto a discusión.
- He dejado las [expresiones "yield"](https://docs.python.org/3/reference/expressions.html#yield-expressions) con el mismo nombre que en inglés, ya que no he encontrado una traducción que no pueda confundir. Como verbo, lo he traducido como "producir", diferenciando así de "throw (lanzar)" y "raise (generar)".
- He traducido "generator function" como "función generadora", aunque he tenido dudas sobre si elegir "función de generador".
- He traducido "awaitable" por "esperable" por no encontrar otra palabra más adecuada.
- He traducido ["slices" y "slicings"](https://docs.python.org/3/reference/expressions.html#slicings) como "segmentos". He dudado entre muchas palabras pero esta me parece las más adecuada.
- He dejado las [expresiones "await"](https://docs.python.org/3/reference/expressions.html#await-expression) con el mismo nombre que en inglés, ya que "expresión esperar" o "expresión aguardar" me parecen que confundirían. Sin embargo, he traducido "awaitable objects" como "objetos esperables" aunque entiendo que está abierto a discusión.
- He traducido [Shifting operations](https://docs.python.org/3/reference/expressions.html#shifting-operations) como "Operaciones de desplazamiento".
- He traducido valores "not-a-number" por valores "no-un-número".
- He traducido "unhashable" como "inhashable", ya que no he encontrado una palabra que no pueda dar lugar a confusión en el contexto en el que aparece.