### PR TITLE
Dejar sólo diccionario es_ES en CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,6 @@ jobs:
       - name: Pospell
         run: |
           python scripts/create_dict.py
-          pospell -p dict.txt -l es_AR -l es_ES **/*.po
+          pospell -p dict.txt -l es_ES **/*.po
       - name: Construir documentación
         run: PYTHONWARNINGS=ignore::FutureWarning sphinx-build -j auto -W --keep-going -b html -d cpython/Doc/_build/doctree -D language=es . cpython/Doc/_build/html


### PR DESCRIPTION
Tras el merge de #960, la configuración debería sincronizarse con el CI.