### PR TITLE
Ajuste en listado de funciones library/functions.po

### DIFF
--- a/library/functions.po
+++ b/library/functions.po
@@ -80,7 +80,7 @@ msgstr ":func:`any`"
 
 #: ../Doc/library/functions.rst:15
 msgid ":func:`dir`"
-msgstr ":func:`any`"
+msgstr ":func:`dir`"
 
 #: ../Doc/library/functions.rst:15
 msgid ":func:`hex`"


### PR DESCRIPTION
"Hola, quería comentaros un pequeño problema, en la página:
https://docs.python.org/es/3/library/functions.html
Hay una tabla con enlaces a las diferentes funciones, resulta que no aparece el enlace a:
https://docs.python.org/es/3/library/functions.html#dir
En su sitio hay una copia del enlace a:
https://docs.python.org/es/3/library/functions.html#any
Es un pequeño error que hace parecer que no existe la función o que no está documentada".