### PR TITLE
Fix powrap branch on pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/JulienPalard/powrap
-    rev: master
+    rev: main
     hooks:
     -   id: powrap
 -   repo: local


### PR DESCRIPTION
Fix `powrap` repository branch on `pre-commit` config file.

Changed branch from `master` to `main`

Closes #1336 