### PR TITLE
Traduce entradas en library/shutil.po

### DIFF
--- a/library/shutil.po
+++ b/library/shutil.po
@@ -11,15 +11,16 @@ msgstr ""
 "Project-Id-Version: Python 3.8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-03-19 11:16+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2021-08-17 10:12+0800\n"
 "Last-Translator: \n"
 "Language: es\n"
 "Language-Team: python-doc-es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
+"X-Generator: Poedit 2.4.2\n"
 
 #: ../Doc/library/shutil.rst:2
 msgid ":mod:`shutil` --- High-level file operations"
@@ -163,7 +164,7 @@ msgid ""
 "the file more efficiently. See :ref:`shutil-platform-dependent-efficient-"
 "copy-operations` section."
 msgstr ""
-"Los llamadas al sistema de copia rápida específicos de la plataforma se "
+"Las llamadas a sistema de copia rápida específicas de la plataforma se "
 "pueden usar internamente para copiar el archivo de manera más eficiente. "
 "Véase la sección :ref:`shutil-platform-dependent-efficient-copy-operations`."
 
@@ -301,7 +302,6 @@ msgstr ""
 "extendidos de Linux."
 
 #: ../Doc/library/shutil.rst:160
-#, fuzzy
 msgid ""
 "Copies the file *src* to the file or directory *dst*.  *src* and *dst* "
 "should be :term:`path-like objects <path-like object>` or strings.  If *dst* "
@@ -309,9 +309,10 @@ msgid ""
 "filename from *src*.  Returns the path to the newly created file."
 msgstr ""
 "Copia el archivo *src* al archivo o directorio *dst*. *src* y *dst* deberían "
-"ser cadenas de caracteres (*strings*). Si *dst* especifica un directorio, el "
-"archivo será copiado en *dst* usando el nombre de archivo base de *src*. "
-"Retorna la ruta del archivo recién creado."
+"ser :term:`objetos tipo ruta <path-like object>` o cadenas de caracteres "
+"(*strings*). Si *dst* especifica un directorio, el archivo será copiado en "
+"*dst* usando el nombre de archivo base de *src*. Retorna la ruta del archivo "
+"recién creado."
 
 #: ../Doc/library/shutil.rst:165
 msgid ""
@@ -639,7 +640,6 @@ msgstr ""
 "eliminado."
 
 #: ../Doc/library/shutil.rst:351
-#, fuzzy
 msgid ""
 "If *copy_function* is given, it must be a callable that takes two arguments "
 "*src* and *dst*, and will be used to copy *src* to *dst* if :func:`os."
@@ -680,9 +680,9 @@ msgid "Added the *copy_function* keyword argument."
 msgstr "Se agregó el argumento de keyword *copy_function*."
 
 #: ../Doc/library/shutil.rst:374
-#, fuzzy
 msgid "Accepts a :term:`path-like object` for both *src* and *dst*."
-msgstr "Acepta un :term:`path-like object` como *filename* y *extract_dir*."
+msgstr ""
+"Acepta un :term:`objeto tipo ruta <path-like object>` como *src* y *dst*."
 
 #: ../Doc/library/shutil.rst:379
 msgid ""
@@ -797,7 +797,6 @@ msgid "Platform-dependent efficient copy operations"
 msgstr "Operaciones de copia eficientes dependientes de la plataforma"
 
 #: ../Doc/library/shutil.rst:446
-#, fuzzy
 msgid ""
 "Starting from Python 3.8, all functions involving a file copy (:func:"
 "`copyfile`, :func:`~shutil.copy`, :func:`copy2`, :func:`copytree`, and :func:"
@@ -808,16 +807,16 @@ msgid ""
 msgstr ""
 "A partir de Python 3.8, todas las funciones que incluyen una copia de "
 "archivo (:func:`copyfile`, :func:`copy`, :func:`copy2`, :func:`copytree`, y :"
-"func:`move`) puede usar llamadas al sistema \"copia rápida\" para poder "
-"copiar el archivo de forma más eficiente (véase :issue:`33671`). \"copia "
-"rápida\" significa que la operación de copia ocurre dentro del núcleo, "
-"evitando el uso de búferes de espacio de usuario en Python como en \"``outfd."
-"write(infd.read())``\"."
+"func:`move`) puede usar llamadas a sistema de \"copia rápida\" específicas a "
+"cada plataforma para poder copiar el archivo de forma más eficiente (véase :"
+"issue:`33671`). \"copia rápida\" significa que la operación de copia ocurre "
+"dentro del núcleo, evitando el uso de búferes en espacio de usuario en "
+"Python como en \"``outfd.write(infd.read())``\"."
 
 #: ../Doc/library/shutil.rst:454
 msgid "On macOS `fcopyfile`_ is used to copy the file content (not metadata)."
 msgstr ""
-"En macOS, se usar `fcopyfile`_ para copiar el contenido del archivo (pero no "
+"En macOS, se usa `fcopyfile`_ para copiar el contenido del archivo (pero no "
 "los metadatos)."
 
 #: ../Doc/library/shutil.rst:456
@@ -928,27 +927,27 @@ msgstr ""
 "módulo :mod:`bz2` está disponible), o \"xztar\" (si el módulo :mod:`lzma`)."
 
 #: ../Doc/library/shutil.rst:573
-#, fuzzy
 msgid ""
 "*root_dir* is a directory that will be the root directory of the archive, "
 "all paths in the archive will be relative to it; for example, we typically "
 "chdir into *root_dir* before creating the archive."
 msgstr ""
-"*root_dir* es un directorio que será el directorio raíz del archivo; por "
-"ejemplo, iremos al directorio (*chdir*) a *root_dir* antes de crear el "
-"archivo."
+"*root_dir* es un directorio que será el directorio raíz del archivo, todas "
+"las rutas en el archivo serán relativas a él; por ejemplo, típicamente nos "
+"cambiaremos de directorio (*chdir*) a *root_dir* antes de crear el archivo."
 
 #: ../Doc/library/shutil.rst:577
-#, fuzzy
 msgid ""
 "*base_dir* is the directory where we start archiving from; i.e. *base_dir* "
 "will be the common prefix of all files and directories in the archive.  "
 "*base_dir* must be given relative to *root_dir*.  See :ref:`shutil-archiving-"
 "example-with-basedir` for how to use *base_dir* and *root_dir* together."
 msgstr ""
-"*base_dir* es el directorio desde donde iniciamos el archivado ; por "
-"ejemplo, *base_dir* será el prefijo común para todos los archivos y "
-"directorios en el archivo."
+"*base_dir* es el directorio desde donde iniciamos el archivado; i.e, "
+"*base_dir* será el prefijo común para todos los archivos y directorios en el "
+"archivo. *base_dir* debe ser dado de forma relativa a *root_dir*. En :ref:"
+"`shutil-archiving-example-with-basedir` se ve un ejemplo de cómo usar "
+"*base_dir* y *root_dir* juntos."
 
 #: ../Doc/library/shutil.rst:583
 msgid "*root_dir* and *base_dir* both default to the current directory."
@@ -1018,7 +1017,7 @@ msgstr "*zip*: archivo ZIP (si el módulo :mod:`zlib` está disponible)."
 msgid ""
 "*tar*: Uncompressed tar file. Uses POSIX.1-2001 pax format for new archives."
 msgstr ""
-"*tar*: archivo tar sin comprimir. Utiliza POSIX.1-2001 formato pax para "
+"*tar*: archivo tar sin comprimir. Utiliza el formato pax POSIX.1-2001 para "
 "archivos nuevos."
 
 #: ../Doc/library/shutil.rst:612 ../Doc/library/shutil.rst:695
@@ -1213,9 +1212,8 @@ msgid "The resulting archive contains:"
 msgstr "El archivo resultante contiene:"
 
 #: ../Doc/library/shutil.rst:736
-#, fuzzy
 msgid "Archiving example with *base_dir*"
-msgstr "Ejemplo de archivado"
+msgstr "Ejemplo de archivado con *base_dir*"
 
 #: ../Doc/library/shutil.rst:738
 msgid ""
@@ -1223,16 +1221,21 @@ msgid ""
 "show how to use :func:`make_archive`, but this time with the usage of "
 "*base_dir*.  We now have the following directory structure:"
 msgstr ""
+"En este ejemplo, similar al `de arriba <shutil-archiving-example_>`_, "
+"mostramos cómo usar :func:`make_archive`, pero esta vez utilizando "
+"*base_dir*.  Ahora tenemos la siguiente estructura de directorios:"
 
 #: ../Doc/library/shutil.rst:752
 msgid ""
 "In the final archive, :file:`please_add.txt` should be included, but :file:"
 "`do_not_add.txt` should not.  Therefore we use the following::"
 msgstr ""
+"En el archivo final, :file:`please_add.txt` debería estar incluido, pero :"
+"file:`do_not_add.txt` no.  Por lo tanto usamos lo siguiente::"
 
 #: ../Doc/library/shutil.rst:766
 msgid "Listing the files in the resulting archive gives us:"
-msgstr ""
+msgstr "Listando los archivos en el archivo resultante nos da:"
 
 #: ../Doc/library/shutil.rst:776
 msgid "Querying the size of the output terminal"
@@ -1258,7 +1261,7 @@ msgid ""
 "terminal connected to :data:`sys.__stdout__` is queried by invoking :func:"
 "`os.get_terminal_size`."
 msgstr ""
-"Cuando `COLUMNS`` o ``LINES`` no está definido, como suele ocurrir, la "
+"Cuando ``COLUMNS`` o ``LINES`` no está definido, como suele ocurrir, la "
 "terminal conectada a :data:`sys.__stdout__` se consulta invocando :func:`os."
 "get_terminal_size`."
 
@@ -1283,10 +1286,9 @@ msgstr ""
 "terminal_size`."
 
 #: ../Doc/library/shutil.rst:798
-#, fuzzy
 msgid ""
 "See also: The Single UNIX Specification, Version 2, `Other Environment "
 "Variables`_."
 msgstr ""
-"Véase también: *The Single UNIX Specification*, Versión 2, `Other "
-"Environment Variables`_."
+"Ver también: *The Single UNIX Specification*, Versión 2, `Other Environment "
+"Variables`_."


### PR DESCRIPTION
Este commit incluye la traudcción de las entradas faltantes en shutil,
además de arreglar las entradas que estaban marcadas como fuzzy, y
corregir un par de errores pequeños de traducción.

Closes #1280 