### PR TITLE
Soluciona problemas intermitentes con pospell

### DIFF
--- a/dictionaries/whatsnew_3.5.txt
+++ b/dictionaries/whatsnew_3.5.txt
@@ -1,5 +1,4 @@
 Joiner
-Oberkirch
 Welbourne
 Landau
 scandir
@@ -93,7 +92,6 @@ Natali
 Nathaniel
 Navarrete
 Nikolaus
-OberKirch
 Oberkirch
 Panter
 Paroz

--- a/whatsnew/3.5.po
+++ b/whatsnew/3.5.po
@@ -2607,7 +2607,7 @@ msgid ""
 msgstr ""
 "Un nuevo comando :meth:`POP3.utf8() <poplib.POP3.utf8>` habilita el soporte "
 "(correo electrónico internacionalizado) :rfc:`6856`, si un servidor POP lo "
-"admite. (Contribución de Milan OberKirch en :issue:`21804`.)"
+"admite. (Contribución de Milan Oberkirch en :issue:`21804`.)"
 
 #: ../Doc/whatsnew/3.5.rst:1584
 msgid "re"


### PR DESCRIPTION
Como fue discutido en #1352, la solución más simple por el momento es usar la misma forma de Oberkirch (en vez de usar OberKirch en algunas entradas), y remover OberKirch del diccionario.

Closes #1352 

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>