### PR TITLE
Agrego Memoria de Traducción como bloque independiente

### DIFF
--- a/.overrides/CONTRIBUTING.rst
+++ b/.overrides/CONTRIBUTING.rst
@@ -161,9 +161,6 @@ A tener en cuenta
   ejemplo un artículo a Wikipedia). En caso de que no haya una traducción del
   artículo en Wikipedia deja el título sin traducir.
 
-* Tenemos una :doc:`Memoria de Traducción <translation-memory>`, que usamos para tener
-  consistencia con algunos términos.
-
 * Si tienes una **duda sobre una palabra o término**, escríbelo como mejor suene
   para vos y marca ese párrafo como "Need work" / "Necesita trabajo" en
   *poedit*. Además, escribe un comentario explicando cuál es el termino en ese
@@ -202,6 +199,16 @@ Allí debería haber uno que diga ``docs/readthedocs.org:python-docs-es`` y al l
 
 Haciendo click en ese link verás una versión de la documentación completa que incluirá todos tus cambios.
 Tendrás que navegar hasta el archivo que hayas cambiado para ver cómo se visualiza luego del build.
+
+
+Memoria de traducción
+---------------------
+
+Tenemos una :doc:`Memoria de Traducción <translation-memory>`, que usamos para tener consistencia con algunos
+términos. 
+Si tienes alguna duda respecto a cómo traducir alguna palabra no te olvides de revisar este contenido.
+Del mismo modo, si luego de trabajar sobre un término *complicado* llegas a un acuerdo con otros colaboradores: 
+no se olviden de agregarlo.
 
 
 .. _repositorio: https://github.com/python/python-docs-es


### PR DESCRIPTION
Me pasa que cada vez que quiero revisar la **Memoria de Traducción** tengo que scrollear [CONTRIBUTING.RST](https://python-docs-es.readthedocs.io/es/3.10/CONTRIBUTING.html) y me cuesta encontrar dónde hacer click. 

Pienso que si posicionamos el párrafo como un apartado más del documento (a la vista en el índice) puede hacer que lo tengamos más presente y continuemos agregando algunos conceptos más.
¿Qué dicen? 