### PR TITLE
Upgrade pospell v1.0.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         language: python
 # This one requires package ``hunspell-es_es`` in Archlinux
 -   repo: https://github.com/AFPy/pospell
-    rev: v1.0.12
+    rev: v1.0.13
     hooks:
     -   id: pospell
         args: ['--personal-dict', 'dict.txt', '--language', 'es_ES', '--language', 'es_AR']


### PR DESCRIPTION
Upgrade `pospell` to v1.0.13 to avoid `pospell` issues on fresh installs with message: `AttributeError: 'Text' object has no attribute 'rawsource'`.