### PR TITLE
Actualiza versión mínima requerida de pospell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         language: python
 # This one requires package ``hunspell-es_es`` in Archlinux
 -   repo: https://github.com/AFPy/pospell
-    rev: v1.0.13
+    rev: v1.1
     hooks:
     -   id: pospell
         args: ['--personal-dict', 'dict.txt', '--language', 'es_ES', '--language', 'es_AR']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pip==21.1
 Sphinx==3.2.1
 blurb
 polib
-pospell==1.0.12
+pospell>=1.1
 potodo
 powrap
 python-docs-theme


### PR DESCRIPTION
La versión 1.1 trae consigo mejoras de rendimiento y corrige una falla en el manejo de las opciones de línea de comando.