### PR TITLE
Actualiza traducción de installing/index.po

### DIFF
--- a/installing/index.po
+++ b/installing/index.po
@@ -11,15 +11,16 @@ msgstr ""
 "Project-Id-Version: Python 3.8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-10-16 21:42+0200\n"
-"PO-Revision-Date: 2020-05-30 13:44+0200\n"
-"Last-Translator: Xavi Francisco <xavi@srxavi.me>\n"
+"PO-Revision-Date: 2021-12-09 10:09+0800\n"
+"Last-Translator: Rodrigo Tobar <rtobarc@gmail.com>\n"
 "Language: es_ES\n"
 "Language-Team: python-doc-es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
+"X-Generator: Poedit 3.0\n"
 
 #: ../Doc/installing/index.rst:7
 msgid "Installing Python Modules"
@@ -124,12 +125,11 @@ msgstr ""
 "automáticamente ``pip`` en los entornos recién creados."
 
 #: ../Doc/installing/index.rst:47
-#, fuzzy
 msgid ""
 "The `Python Package Index <https://pypi.org>`__ is a public repository of "
 "open source licensed packages made available for use by other Python users."
 msgstr ""
-"El `Índice de paquetes de Python <https://pypi.org>`__ es un repositorio "
+"El `Índice de Paquetes de Python <https://pypi.org>`__ es un repositorio "
 "público de paquetes bajo licencias de código abierto disponibles para otros "
 "usuarios de Python."
 
@@ -192,21 +192,19 @@ msgstr ""
 "desde la línea de comandos."
 
 #: ../Doc/installing/index.rst:80
-#, fuzzy
 msgid ""
 "The following command will install the latest version of a module and its "
 "dependencies from the Python Package Index::"
 msgstr ""
 "El siguiente comando instalará la última versión de un módulo y sus "
-"dependencias desde el índice de paquetes de Python::"
+"dependencias desde el Índice de Paquetes de Python::"
 
 #: ../Doc/installing/index.rst:87
-#, fuzzy
 msgid ""
 "For POSIX users (including macOS and Linux users), the examples in this "
 "guide assume the use of a :term:`virtual environment`."
 msgstr ""
-"Para usuarios POSIX (incluyendo los usuarios de MacOS y Linux), los ejemplos "
+"Para usuarios POSIX (incluyendo los usuarios de macOS y Linux), los ejemplos "
 "en esta guía asumen que se está usando un :term:`virtual environment`."
 
 #: ../Doc/installing/index.rst:90
@@ -344,13 +342,12 @@ msgid "... work with multiple versions of Python installed in parallel?"
 msgstr "... trabajo con múltiples versiones de Python instaladas en paralelo?"
 
 #: ../Doc/installing/index.rst:166
-#, fuzzy
 msgid ""
 "On Linux, macOS, and other POSIX systems, use the versioned Python commands "
 "in combination with the ``-m`` switch to run the appropriate copy of "
 "``pip``::"
 msgstr ""
-"En Linux, Mac OS X y otros sistemas POSIX, usa los comandos versionados de "
+"En Linux, macOS y otros sistemas POSIX, usa los comandos versionados de "
 "Python en combinación con la opción `` -m`` para ejecutar la copia apropiada "
 "de ``pip`` ::"
 
@@ -433,7 +430,6 @@ msgstr ""
 "extensión desde la fuente como parte del proceso de instalación."
 
 #: ../Doc/installing/index.rst:227
-#, fuzzy
 msgid ""
 "With the introduction of support for the binary ``wheel`` format, and the "
 "ability to publish wheels for at least Windows and macOS through the Python "
@@ -443,7 +439,7 @@ msgid ""
 msgstr ""
 "Con la introducción del soporte para el formato binario ``wheel``, y la "
 "posibilidad de publicar paquetes en formato ``wheel`` por lo menos para "
-"Windows y Mac OS X a través del Índice de paquetes de Python, se espera que "
+"Windows y macOS a través del Índice de Paquetes de Python, se espera que "
 "este problema se atenúe con el tiempo, ya que los usuarios pueden, con mayor "
 "regularidad, instalar extensiones precompiladas en lugar de tener que "
 "compilarlas."


### PR DESCRIPTION
Todas las referencias a PyPI ahora dicen "Índice de Paquetes de Python",
y todas las referencias a macOS se escriben como tal.

No había un issue para este archivo, así que no hay nada que cerrar cuando esto se mergee.