### PR TITLE
Pequeña clarificación en CONTRIBUTING.rst

### DIFF
--- a/.overrides/CONTRIBUTING.rst
+++ b/.overrides/CONTRIBUTING.rst
@@ -114,7 +114,7 @@ realizado para no traducir dos veces lo mismo.  El proceso para traducir un
 archivo es el siguiente:
 
 
-#. Elige cualquier de los que *no están asignados* a otra persona.
+#. Elige cualquiera de los issues que *no están asignados* a otra persona.
 #. Deja un comentario en el issue diciendo que quieres trabajar en él.
 #. Espera a que un administrador te asigne el issue.
 #. ¡Empieza a traducir!


### PR DESCRIPTION
Se corrige un error tipográfico y se explicita que la línea se refiere a issues (y no a archivos).

En concreto, se ha cambiado:
> El proceso para traducir un archivo es el siguiente:
> Elige cualquier de los que no están asignados a otra persona.
<br>

que ahora pasa a ser (se resaltan los cambios en monoespaciado):
> El proceso para traducir un archivo es el siguiente:
> Elige cualquier`a` de los `issues` que *no están asignados* a otra persona.
