### PR TITLE
Chequea orden en TRANSLATORS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,14 @@ jobs:
       - name: Instalar dependencias
         run: |
           sudo apt-get update
-          sudo apt-get install -y hunspell hunspell-es gettext
+          sudo apt-get install -y hunspell hunspell-es gettext language-pack-es
           python -m pip install -r requirements.txt
           pip list
           pospell --version
           powrap --version
+      - name: TRANSLATORS
+        run: |
+          diff -Naur TRANSLATORS <(LANG=es python scripts/sort.py < TRANSLATORS)
       - name: Powrap
         run: powrap --check --quiet **/*.po
       - name: Pospell

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pip==21.1
 Sphinx==3.2.1
 blurb
+PyICU
 polib
 pospell>=1.1
 potodo

--- a/scripts/sort.py
+++ b/scripts/sort.py
@@ -1,0 +1,8 @@
+import sys
+
+import icu
+
+
+collator = icu.Collator.createInstance(icu.Locale())
+sorted_entries = sorted(sys.stdin, key=collator.getSortKey)
+print("".join(sorted_entries), end='')


### PR DESCRIPTION
Dado que el archivo `TRANSLATORS` fue ordenado alfabéticamente, sería bueno mantener ese orden en el futuro.

Este PR agrega un paso en el GitHub actions para chequear que el archivo sigue estando ordenado alfabéticamente, y genera un error de no ser así. El chequeo se hace comparando el archivo sin modificar contra la salida de un nuevo script `scripts/sort.py`, el cual lee el archivo, ordena las entradas alfabéticamente, e imprime el resultado. Si el resultado es igual al contenido del archivo entonces el archivo está ya ordenado.

El script es genérico, por lo que puede ser usado en el futuro para otras tareas similares.