### PR TITLE
omitir warnings de 'availability' y 'wasm-notavail'

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -44,9 +44,7 @@ html_title = f'Documentación de Python en Español -- {release}'
 _exclude_patterns = [
     # This file is not included and it's not marked as :orphan:
     'distutils/_setuptools_disclaimer.rst',
-    'cpython/Doc/distutils/_setuptools_disclaimer.rst',
-    'cpython/Doc/library/cpython/Doc/includes/wasm-notavail.rst',
-    'cpython/Doc/install/cpython/Doc/distutils/_setuptools_disclaimer.rst'
+    'includes/wasm-notavail.rst',
 ]
 if 'exclude_patterns' in globals():
     exclude_patterns += _exclude_patterns

--- a/library/os.po
+++ b/library/os.po
@@ -637,6 +637,7 @@ msgstr ""
 #: ../Doc/library/os.rst:2308 ../Doc/library/os.rst:3133
 #: ../Doc/library/os.rst:3747 ../Doc/library/os.rst:4236
 #: ../Doc/library/os.rst:4247 ../Doc/library/os.rst:4365
+#, fuzzy
 msgid ":ref:`Availability <availability>`: Unix, Windows."
 msgstr ":ref:`Disponibilidad <availability>`: Unix, Windows."
 
@@ -671,6 +672,7 @@ msgstr ""
 #: ../Doc/library/os.rst:4805 ../Doc/library/os.rst:4814
 #: ../Doc/library/os.rst:4835 ../Doc/library/os.rst:4845
 #: ../Doc/library/os.rst:4855
+#, fuzzy
 msgid ":ref:`Availability <availability>`: Unix."
 msgstr ":ref:`Disponibilidad <availability>`: Unix."
 
@@ -7549,143 +7551,3 @@ msgid ""
 msgstr ""
 "Si se establece este bit, los bytes aleatorios se extraen del grupo ``/dev/"
 "random`` en lugar del grupo ``/dev/urandom``."
-
-#~ msgid ""
-#~ "Bytes version of :data:`environ`: a :term:`mapping` object representing "
-#~ "the environment as byte strings. :data:`environ` and :data:`environb` are "
-#~ "synchronized (modify :data:`environb` updates :data:`environ`, and vice "
-#~ "versa)."
-#~ msgstr ""
-#~ "Versión en *bytes* de :data:`environ`:, un objeto  :term:`mapeado` "
-#~ "representando el entorno como cadena de *bytes*. :data:`environ` y :data:"
-#~ "`environb` están sincronizados (modificar :data:`environb` actualiza :"
-#~ "data:`environ` y viceversa)."
-
-#~ msgid ""
-#~ "Return the value of the environment variable *key* if it exists, or "
-#~ "*default* if it doesn't. *key*, *default* and the result are str."
-#~ msgstr ""
-#~ "Retorna el valor de la variable de entorno especificado como clave "
-#~ "(*key*), si existe, o *default* si no existe. *key*, *default* y el "
-#~ "resultado son cadenas de texto."
-
-#~ msgid ":ref:`Availability <availability>`: most flavors of Unix, Windows."
-#~ msgstr ":ref:`Disponibilidad <availability>`: sistemas tipo Unix, Windows."
-
-#~ msgid ""
-#~ "Return the value of the environment variable *key* if it exists, or "
-#~ "*default* if it doesn't. *key*, *default* and the result are bytes."
-#~ msgstr ""
-#~ "Retorna el valor de la variable de entorno especificado como clave "
-#~ "(*key*), si existe, o *default* si no existe. *key*, *default* y el "
-#~ "resultado son *bytes*."
-
-#~ msgid ":ref:`Availability <availability>`: most flavors of Unix."
-#~ msgstr ":ref:`Disponibilidad <availability>`: sistemas tipo Unix."
-
-#~ msgid ":ref:`Availability <availability>`: recent flavors of Unix."
-#~ msgstr ""
-#~ ":ref:`Disponibilidad <availability>`: sistemas tipo Unix más nuevos."
-
-#~ msgid ":ref:`Availability <availability>`: some flavors of Unix."
-#~ msgstr ":ref:`Disponibilidad <availability>`: algunos sistemas tipo Unix."
-
-#~ msgid ""
-#~ ":ref:`Availability <availability>`: Linux 2.6.30 and newer, FreeBSD 6.0 "
-#~ "and newer, OpenBSD 2.7 and newer, AIX 7.1 and newer. Using flags requires "
-#~ "Linux 4.6 or newer."
-#~ msgstr ""
-#~ ":ref:`Disponibilidad <availability>`: Linux 2.6.30 y posterior, FreeBSD "
-#~ "6.0 y posterior, OpenBSD 2.7 y posterior, AIX 7.1 y posterior. El uso de "
-#~ "flags requiere Linux 4.6 o posterior."
-
-#~ msgid ":ref:`Availability <availability>`: Linux 4.14 and newer."
-#~ msgstr ":ref:`Disponibilidad <availability>`: Linux 4.14 y más nuevos."
-
-#~ msgid ":ref:`Availability <availability>`: Linux 4.6 and newer."
-#~ msgstr ":ref:`Disponibilidad <availability>`: Linux 4.6 y más nuevos."
-
-#~ msgid ""
-#~ ":ref:`Availability <availability>`: Linux 2.6.30 and newer, FreeBSD 6.0 "
-#~ "and newer, OpenBSD 2.7 and newer, AIX 7.1 and newer. Using flags requires "
-#~ "Linux 4.7 or newer."
-#~ msgstr ""
-#~ ":ref:`Disponibilidad <availability>`: Linux 2.6.30 y posterior, FreeBSD "
-#~ "6.0 y posterior, OpenBSD 2.7 y posterior, AIX 7.1 y posterior. El uso de "
-#~ "flags requiere Linux 4.7 o posterior."
-
-#~ msgid ":ref:`Availability <availability>`: Linux 4.7 and newer."
-#~ msgstr ":ref:`Disponibilidad <availability>`: Linux 4.7 y más nuevos."
-
-#~ msgid ":ref:`Availability <availability>`: Linux 4.16 and newer."
-#~ msgstr ":ref:`Disponibilidad <availability>`: Linux 4.16 y más nuevos."
-
-#~ msgid "If the directory already exists, :exc:`FileExistsError` is raised."
-#~ msgstr "Si el directorio ya existe, se excita :exc:`FileExistsError`."
-
-#~ msgid ""
-#~ "Rename the file or directory *src* to *dst*.  If *dst* is a directory, :"
-#~ "exc:`OSError` will be raised.  If *dst* exists and is a file, it will be "
-#~ "replaced silently if the user has permission.  The operation may fail if "
-#~ "*src* and *dst* are on different filesystems.  If successful, the "
-#~ "renaming will be an atomic operation (this is a POSIX requirement)."
-#~ msgstr ""
-#~ "Cambia el nombre del archivo o directorio *src* a *dst*. Si *dst* es un "
-#~ "directorio, se lanzará :exc:`OSError`. Si *dst* existe y es un archivo, "
-#~ "será reemplazado silenciosamente si el usuario tiene permiso. La "
-#~ "operación puede fallar si *src* y *dst* están en sistemas de archivos "
-#~ "diferentes. Si tiene éxito, el cambio de nombre será una operación "
-#~ "atómica (este es un requisito POSIX)."
-
-#~ msgid ""
-#~ ":ref:`Availability <availability>`: Linux 3.17 or newer with glibc 2.27 "
-#~ "or newer."
-#~ msgstr ""
-#~ ":ref:`Disponibilidad <availability>`: Linux 3.17 o posterior con glibc "
-#~ "2.27 o posterior."
-
-#~ msgid ""
-#~ ":ref:`Availability <availability>`: Linux 3.17 or newer with glibc 2.27 "
-#~ "or newer.  The ``MFD_HUGE*`` flags are only available since Linux 4.14."
-#~ msgstr ""
-#~ ":ref:`Disponibilidad <availability>`: Linux 3.17 o posterior con glibc "
-#~ "2.27 o posterior. Los indicadores ``MFD_HUGE*`` solo están disponibles "
-#~ "desde Linux 4.14."
-
-#~ msgid ""
-#~ ":ref:`Availability <availability>`: Linux 2.6.27 or newer with glibc 2.8 "
-#~ "or newer."
-#~ msgstr ""
-#~ ":ref:`Disponibilidad <availability>`: Linux 2.6.27 o posterior con glibc "
-#~ "2.8 o posterior."
-
-#~ msgid ":ref:`Availability <availability>`: See :func:`eventfd`"
-#~ msgstr ":ref:`Disponibilidad <availability>`: Ver :func:`eventfd`"
-
-#~ msgid ""
-#~ ":ref:`Availability <availability>`: Linux 2.6.30 or newer with glibc 2.8 "
-#~ "or newer."
-#~ msgstr ""
-#~ ":ref:`Disponibilidad <availability>`: Linux 2.6.30 o posterior con glibc "
-#~ "2.8 o posterior."
-
-#~ msgid "Exit code that means no error occurred."
-#~ msgstr "Código de salida que significa que no se produjo ningún error."
-
-#~ msgid ""
-#~ ":ref:`Availability <availability>`: Unix, Windows.  :func:`spawnlp`, :"
-#~ "func:`spawnlpe`, :func:`spawnvp` and :func:`spawnvpe` are not available "
-#~ "on Windows.  :func:`spawnle` and :func:`spawnve` are not thread-safe on "
-#~ "Windows; we advise you to use the :mod:`subprocess` module instead."
-#~ msgstr ""
-#~ ":ref:`Disponibilidad <availability>`: Unix, Windows. :func:`spawnlp`, :"
-#~ "func:`spawnlpe`, :func:`spawnvp` y :func:`spawnvpe` no están disponibles "
-#~ "en Windows. :func:`spawnle` y :func:`spawnve` no son seguros para "
-#~ "subprocesos en Windows; le recomendamos que utilice el módulo :mod:"
-#~ "`subprocess` en su lugar."
-
-#~ msgid ":ref:`Availability <availability>`: some Unix systems."
-#~ msgstr ":ref:`Disponibilidad <availability>`: algunos sistemas Unix."
-
-#~ msgid ":ref:`Availability <availability>`: Linux 3.17 and newer."
-#~ msgstr ":ref:`Disponibilidad <availability>`: Linux 3.17 y más reciente."


### PR DESCRIPTION
edit: including explanation
----
the whole story on the 'availability' warnings are that there is a `.. availability::` command in the cpython docs that include, in some cases, stuff from the 'wasm-availability' file. So we have references "within" the 'availabiliy' command.

as you can see, the entry has no mention of WASM or wahtsover in some entries, like "Unix, Windows",
but still will generate the following warning:

```
cpython/Doc/library/os.rst:: WARNING: inconsistent term references in translated message. original: [':ref:`Availability <availability>`', ':ref:`wasm-availability`'], translated: [':ref:`Disponibilidad <availability>`']
```

The reason that due to the internal reference to 'wasm-availability' , even in cases like this entry, where it's only Unix and Windows, for example:

   https://docs.python.org/3.11/library/os.html?highlight=os#os.getenv

it generates the reference to the 'Availability' page, which inside has the 'wasm-availability' inside:

   https://docs.python.org/3.11/library/intro.html#availability


Additionally, the `wasm-notavail` file is excluded to avoid the warning related to the file not being inclued in any index. We could have add `:orphan:` to the file inside `cpython` but we do it via the exclude patterns to avoid touching files on the submodule.
