### PR TITLE
Removed reference to target 'dict_dups' in Makefile

### DIFF
--- a/.overrides/progress.rst
+++ b/.overrides/progress.rst
@@ -10,7 +10,7 @@ y otras estadísticas.
 
 .. note::
 
-   Estas listas se actualiza automáticamente cuando Pull Requests se *mergean* a la rama ``3.10``.
+   Estas listas se actualiza automáticamente cuando Pull Requests se *mergean* a la rama ``3.11``.
 
 
 En progreso

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ help:
 	@echo " spell        Check spelling"
 	@echo " wrap         Wrap all the PO files to a fixed column width"
 	@echo " progress     To compute current progression on the tutorial"
-	@echo " dict_dups	Check duplicated entries on the dict"
 	@echo ""
 
 


### PR DESCRIPTION
Target dict-dups was removed in https://github.com/python/python-docs-es/commit/059f83466ab839f02db2db5bb41d2a05d9d96435