### PR TITLE
Agrego traducción faltante en el índice

### DIFF
--- a/sphinx.po
+++ b/sphinx.po
@@ -9,15 +9,15 @@ msgstr ""
 "Project-Id-Version: Python 3.8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-05-06 11:59-0400\n"
-"PO-Revision-Date: 2020-05-06 09:33-0300\n"
+"PO-Revision-Date: 2022-10-29 14:12+0200\n"
+"Last-Translator: \n"
+"Language-Team: python-doc-es\n"
+"Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Last-Translator: \n"
-"Language-Team: python-doc-es\n"
-"Language: es_ES\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 3.1.1\n"
 
 #: ../Doc/tools/templates/customsourcelink.html:3
 msgid "This Page"
@@ -74,7 +74,7 @@ msgstr "Referencia de la Biblioteca"
 
 #: ../Doc/tools/templates/indexcontent.html:18
 msgid "keep this under your pillow"
-msgstr "Mantén esto bajo tu almohada"
+msgstr "mantén esto bajo tu almohada"
 
 #: ../Doc/tools/templates/indexcontent.html:19
 msgid "Language Reference"
@@ -90,7 +90,7 @@ msgstr "Configuración y uso de Python"
 
 #: ../Doc/tools/templates/indexcontent.html:22
 msgid "how to use Python on different platforms"
-msgstr "como usar Python en diferentes plataformas"
+msgstr "cómo usar Python en diferentes plataformas"
 
 #: ../Doc/tools/templates/indexcontent.html:23
 msgid "Python HOWTOs"
@@ -197,6 +197,10 @@ msgstr "Reportar errores"
 #: ../Doc/tools/templates/indexcontent.html:60
 msgid "About the documentation"
 msgstr "Acerca de la documentación"
+
+#: ../Doc/tools/templates/indexcontent.html:61
+msgid "Contributing to Docs"
+msgstr "Contribuyendo con la Documentación"
 
 #: ../Doc/tools/templates/indexcontent.html:62
 msgid "History and License of Python"


### PR DESCRIPTION
La línea "Contributing to docs" de `indexcontent.html` no estaba disponible para traducción en el archivo `sphinx.po`