### PR TITLE
Remove reference to Zulip

### DIFF
--- a/.overrides/coc.rst
+++ b/.overrides/coc.rst
@@ -169,7 +169,6 @@ Este Código de conducta se aplica a los siguientes espacios en línea:
 
 * listas de correo python-ideas, core-mentorship, python-dev, docs
 * Todas las demás listas de correo alojadas en python.org
-* Servidor de chat *Zulip* de la *Python Software Foundation*
 * Servidor *Discourse* alojado en discuss.python.org
 * Repositorios de código, rastreadores de problemas y solicitudes de extracción realizadas contra
   cualquier organización GitHub controlada por la *Python Software Foundation*


### PR DESCRIPTION
The Zulip server is no longer used and will be closed down: https://github.com/python/core-workflow/issues/457

Let's remove the reference from the docs.

I believe it can be removed ahead of shutting down the server, because it's nevertheless covered by the catch-all:

* "Cualquier otro espacio en línea administrado por la *Python Software Foundation*"
* "Any other online space administered by the Python Software Foundation"
