### PR TITLE
Usar cache para dependencias

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+          cache: "pip"
       - name: Sincronizar con CPython
         run: |
           git submodule update --init --depth=1 cpython


### PR DESCRIPTION
La acción que instala python en GutHub Actions puede crear un caché con las dependencias instaladas durante una corrida. Usar este cache debería hacer que nuestros tests en CI corran más rápido.