### PR TITLE
Usar Pygments < 2.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pip
 Sphinx==4.5.0
 blurb
+Pygments<2.15
 PyICU
 polib
 pospell>=1.1


### PR DESCRIPTION
La última versión de Pygments está provocando errores al parsear código de python que es válido. Esto ya ha sido reportado en https://github.com/pygments/pygments/issues/2407, sólo hace falta esperar por el fix, y mientras tanto evitar usar esta nueva versión.

Este problema fue visto en #2372 por primera vez, pero de hecho ya nos está afectando: el último build en CI de `3.11` ya falló por la misma razón.