### PR TITLE
No ignorar archivos que tienen sólo entradas fuzzy

### DIFF
--- a/scripts/create_issue.py
+++ b/scripts/create_issue.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 from github import Github
-from potodo._po_file import PoFileStats
+from potodo.potodo import PoFileStats
 
 if len(sys.argv) != 2:
     print('Specify PO filename')
@@ -32,7 +32,7 @@ for issue in issues:
         if answer != 'y':
             sys.exit(1)
 
-if any([
+if pofile.fuzzy == 0 and any([
     pofile.translated_nb == pofile.po_file_size,
     pofile.untranslated_nb == 0,
 ]):


### PR DESCRIPTION
Me di cuenta que en la página de [progreso de la traducción](https://python-docs-es.readthedocs.io/es/3.11/progress.html) quedan muchos archivos que sólo tienen entradas fuzzy para verificar, pero no hay un issue creado.

En esta PR agrego una condición al script `create_issue.py` para que esos archivos no sean ignorados.

Además, actualizo un import que no funciona con la version actual de `potodo`.