### PR TITLE
Add stale action for PR and Issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,5 +14,5 @@ jobs:
           days-before-issue-stale: 10
           days-before-pr-stale: 7
           days-before-pr-close: 21
-          stale-issue-message: 'Hola, este issue lleva un tiempo sin novedades. Estás trabajando todavía?\nSi necesitas ayuda :sos: no dudes en contactarnos en nuestro grupo de Telegram.'
-          stale-pr-message: 'Hola, este PR lleva un tiempo sin novedades. Vamos a pedir a un admin de nuestro equipo que decida si alguien más puede finalizar este PR o si tenemos que cancelarlo.\nPor favor avisanos en caso de que aún puedas tomarte el tiempo para terminarlo'
+          stale-issue-message: 'Este issue lleva un tiempo sin actualizaciones. ¿Estás trabajando todavía?\nSi necesitas ayuda :sos: no dudes en contactarnos en nuestro [grupo de Telegram](https://t.me/python_docs_es).'
+          stale-pr-message: 'Este PR lleva un tiempo sin actualizaciones. Vamos a pedir a un admin de nuestro equipo que decida si alguien más puede finalizarlo o si tenemos que cerrarlo.\nPor favor, avisanos en caso de que aún puedas terminarlo'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,18 @@
+name: 'Cierra issues y PRs antiguos'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-pr-label: 'needs decision'
+          stale-issue-label: 'stale'
+          days-before-issue-stale: 10
+          days-before-pr-stale: 7
+          days-before-pr-close: 21
+          stale-issue-message: 'Hola, este issue lleva un tiempo sin novedades. Estás trabajando todavía?\nSi necesitas ayuda :sos: no dudes en contactarnos en nuestro grupo de Telegram.'
+          stale-pr-message: 'Hola, este PR lleva un tiempo sin novedades. Vamos a pedir a un admin de nuestro equipo que decida si alguien más puede finalizar este PR o si tenemos que cancelarlo.\nPor favor avisanos en caso de que aún puedas tomarte el tiempo para terminarlo'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -15,4 +15,4 @@ jobs:
           days-before-pr-stale: 7
           days-before-pr-close: 21
           stale-issue-message: 'Este issue lleva un tiempo sin actualizaciones. ¿Estás trabajando todavía?\nSi necesitas ayuda :sos: no dudes en contactarnos en nuestro [grupo de Telegram](https://t.me/python_docs_es).'
-          stale-pr-message: 'Este PR lleva un tiempo sin actualizaciones. Vamos a pedir a un admin de nuestro equipo que decida si alguien más puede finalizarlo o si tenemos que cerrarlo.\nPor favor, avisanos en caso de que aún puedas terminarlo'
+          stale-pr-message: 'Este PR lleva un tiempo sin actualizaciones. Vamos a pedir a un admin de nuestro equipo que decida si alguien más puede finalizarlo o si tenemos que cerrarlo.\nPor favor, avisanos en caso de que aún puedas terminarlo.'


### PR DESCRIPTION
Esta es una propuesta de reemplazo a ladibug para gestionar el estado de Issues y PRs que han estado sin movimiento en un periodo de tiempo.

Closes #628
Reemplaza #629 