### PR TITLE
Traducido urllib.error.po, entradas 15/15, fuzzy 0

### DIFF
--- a/TRANSLATORS
+++ b/TRANSLATORS
@@ -234,4 +234,3 @@ Xavi Rambla Centellas (@xavirambla)
 Yennifer Paola Herrera Ariza (@Yenniferh)
 Yohanna Padrino (@Yo-hanaPR)
 zejiran
-

--- a/TRANSLATORS
+++ b/TRANSLATORS
@@ -233,3 +233,4 @@ Xavi Rambla Centellas (@xavirambla)
 Yennifer Paola Herrera Ariza (@Yenniferh)
 Yohanna Padrino (@Yo-hanaPR)
 zejiran
+alver joan perez (@JPC501)

--- a/TRANSLATORS
+++ b/TRANSLATORS
@@ -15,6 +15,7 @@ Alfonso Trigo (@alftri)
 Alvar Maciel (@alvarmaciel @amaciel)
 Alvaro Cárdenas (@alvaruz)
 Álvaro Mondéjar Rubio (@mondeja)
+alver joan perez (@JPC501)
 alycolbar
 Ana (@popiula)
 Ana de la Calle
@@ -233,4 +234,4 @@ Xavi Rambla Centellas (@xavirambla)
 Yennifer Paola Herrera Ariza (@Yenniferh)
 Yohanna Padrino (@Yo-hanaPR)
 zejiran
-alver joan perez (@JPC501)
+

--- a/library/urllib.error.po
+++ b/library/urllib.error.po
@@ -104,7 +104,7 @@ msgid ""
 "*msg* attribute."
 msgstr ""
 "Normalmente esto es una cadena de caracteres que explica el motivo de este "
-"error.Un alias para el atributo *msg*."
+"error. Un alias para el atributo *msg*."
 
 #: ../Doc/library/urllib.error.rst:60
 msgid ""

--- a/library/urllib.error.po
+++ b/library/urllib.error.po
@@ -86,7 +86,7 @@ msgstr ""
 
 #: ../Doc/library/urllib.error.rst:44
 msgid "Contains the request URL. An alias for *filename* attribute."
-msgstr ""
+msgstr "Contiene la URL de la solicitud. Un alias para el atributo *filename*."
 
 #: ../Doc/library/urllib.error.rst:49
 msgid ""
@@ -99,29 +99,26 @@ msgstr ""
 "que hay en :attr:`http.server.BaseHTTPRequestHandler.responses`."
 
 #: ../Doc/library/urllib.error.rst:55
-#, fuzzy
 msgid ""
 "This is usually a string explaining the reason for this error. An alias for "
 "*msg* attribute."
 msgstr ""
-"Normalmente esto es una cadena de caracteres que explica el motivo de este "
-"error."
+"Normalmente esto es una cadena de caracteres que explica el motivo de este error." 
+"Un alias para el atributo *msg*."
 
 #: ../Doc/library/urllib.error.rst:60
-#, fuzzy
 msgid ""
 "The HTTP response headers for the HTTP request that caused the :exc:"
 "`HTTPError`. An alias for *hdrs* attribute."
 msgstr ""
 "Las cabeceras de la respuesta HTTP de la petición HTTP que causó el :exc:"
-"`HTTPError`."
+"`HTTPError`. Un alias para el atributo *hdrs*."
 
 #: ../Doc/library/urllib.error.rst:68
 msgid "A file-like object where the HTTP error body can be read from."
-msgstr ""
+msgstr "Un objeto similar a un archivo donde se puede leer el cuerpo del error HTTP."
 
 #: ../Doc/library/urllib.error.rst:72
-#, fuzzy
 msgid ""
 "This exception is raised when the :func:`~urllib.request.urlretrieve` "
 "function detects that the amount of the downloaded data is less than the "
@@ -129,9 +126,8 @@ msgid ""
 msgstr ""
 "Esta excepción se lanza cuando la función :func:`~urllib.request."
 "urlretrieve` detecta que la cantidad de datos descargados es menor que la "
-"esperada (dada por la cabecera *Content-Length*). El atributo :attr:"
-"`content` almacena los datos descargados (y supuestamente truncados)."
+"esperada (dada por la cabecera *Content-Length*)."
 
 #: ../Doc/library/urllib.error.rst:79
 msgid "The downloaded (and supposedly truncated) data."
-msgstr ""
+msgstr "Los datos descargados (y supuestamente truncados)."

--- a/library/urllib.error.po
+++ b/library/urllib.error.po
@@ -103,8 +103,8 @@ msgid ""
 "This is usually a string explaining the reason for this error. An alias for "
 "*msg* attribute."
 msgstr ""
-"Normalmente esto es una cadena de caracteres que explica el motivo de este error." 
-"Un alias para el atributo *msg*."
+"Normalmente esto es una cadena de caracteres que explica el motivo de este "
+"error.Un alias para el atributo *msg*."
 
 #: ../Doc/library/urllib.error.rst:60
 msgid ""
@@ -116,7 +116,8 @@ msgstr ""
 
 #: ../Doc/library/urllib.error.rst:68
 msgid "A file-like object where the HTTP error body can be read from."
-msgstr "Un objeto similar a un archivo donde se puede leer el cuerpo del error HTTP."
+msgstr ""
+"Un objeto similar a un archivo donde se puede leer el cuerpo del error HTTP."
 
 #: ../Doc/library/urllib.error.rst:72
 msgid ""


### PR DESCRIPTION
Closes #2518 - Este PR incluye las traducciones faltantes para el módulo urllib.error. Se han traducido todas las entradas y se han revisado las traducciones fuzzy.
