### PR TITLE
Remove tutorialpyar dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,6 +3,3 @@
 	url = https://github.com/python/cpython.git
 	branch = 3.9
 	shallow = true
-[submodule "tutorialpyar"]
-	path = .migration/tutorialpyar
-	url = https://github.com/pyar/tutorial.git


### PR DESCRIPTION
Even though it was the starting point,
and an esential part of this translation effort,
it's not used anymore.