### PR TITLE
Saltos de línea correctos en stale.yaml

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,5 +14,5 @@ jobs:
           days-before-issue-stale: 10
           days-before-pr-stale: 7
           days-before-pr-close: 21
-          stale-issue-message: 'Este issue lleva un tiempo sin actualizaciones. ¿Estás trabajando todavía?\nSi necesitas ayuda :sos: no dudes en contactarnos en nuestro [grupo de Telegram](https://t.me/python_docs_es).'
-          stale-pr-message: 'Este PR lleva un tiempo sin actualizaciones. Vamos a pedir a un admin de nuestro equipo que decida si alguien más puede finalizarlo o si tenemos que cerrarlo.\nPor favor, avisanos en caso de que aún puedas terminarlo.'
+          stale-issue-message: "Este issue lleva un tiempo sin actualizaciones. ¿Estás trabajando todavía?\nSi necesitas ayuda :sos: no dudes en contactarnos en nuestro [grupo de Telegram](https://t.me/python_docs_es)."
+          stale-pr-message: "Este PR lleva un tiempo sin actualizaciones. Vamos a pedir a un admin de nuestro equipo que decida si alguien más puede finalizarlo o si tenemos que cerrarlo.\nPor favor, avisanos en caso de que aún puedas terminarlo."


### PR DESCRIPTION
Los saltos de líneas escapados no están funcionando como se pretende, e.g. https://github.com/python/python-docs-es/issues/1902#issuecomment-1769763117. Esto es porque los strings en el archivo yaml estaban definidos con comillas simples. Al remplazarlas por comillas dobles deberíamos obtener el resultado deseado (referencia: https://yaml-multiline.info/)