### PR TITLE
Acelera las ejecuciones en CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo sed -i '/postgresql-common/d' /var/lib/dpkg/triggers/File
       - name: Instalar dependencias de sistema
         run: |
-          sudo apt-get install -y hunspell hunspell-es gettext language-pack-es
+          sudo apt-get install -y hunspell hunspell-es gettext language-pack-es locales-all
       - name: Instalar dependencias de Python
         run: |
           python -m pip install -r requirements.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,15 +12,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
       - name: Preparar Python v3.11
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
           cache: "pip"
-      - name: Sincronizar con CPython
-        run: |
-          git submodule update --init --depth=1 cpython
-      - name: Instalar dependencias
         run: |
           sudo apt-get update
           sudo apt-get install -y hunspell hunspell-es gettext language-pack-es

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,6 @@ jobs:
         run: sudo sed -i '/postgresql-common/d' /var/lib/dpkg/triggers/File
       - name: Instalar dependencias de sistema
         run: |
-          sudo apt-get update
           sudo apt-get install -y hunspell hunspell-es gettext language-pack-es
       - name: Instalar dependencias de Python
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,15 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
+      - name: Instalar dependencias de sistema
         run: |
           sudo apt-get update
           sudo apt-get install -y hunspell hunspell-es gettext language-pack-es
+      - name: Instalar dependencias de Python
+        run: |
           python -m pip install -r requirements.txt
+      - name: Listar paquetes y versiones
+        run: |
           pip list
           pospell --version
           powrap --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
+          # Necesario para que tj-actions/changed-files corra
+          # dentro de un tiempo adecuado
+          fetch-depth: 2
 
       # Instalación de dependencias
       - name: Preparar Python v3.11
@@ -37,6 +40,32 @@ jobs:
           pip list
           pospell --version
           powrap --version
+
+      # Cálculo de los archivos .po a verificar.
+      # En el caso de un PR, sólo se chequean los .po que se están editando,
+      # mientras que en caseo de un push a las ramas 3.* queremos revisar
+      # todos los archivos
+      - name: Obtiene la lista de archivos .po con cambios (sólo en PRs)
+        if: github.event_name == 'pull_request'
+        id: changed-po-files
+        uses: tj-actions/changed-files@v40
+        with:
+          files: |
+             **/*.po
+      - name: Calcula lista de archivos .po a revisar
+        id: po-files-to-check
+        env:
+          PO_FILES_TO_CHECK: ${{ steps.changed-po-files.conclusion == 'skipped' && '**/*.po' || steps.changed-po-files.outputs.all_changed_files }}
+        run: |
+          echo "po_files_to_check=$PO_FILES_TO_CHECK" >> $GITHUB_OUTPUT
+          echo "any_po_files_to_check=`test -n \"$PO_FILES_TO_CHECK\" && echo true || echo false`" >> $GITHUB_OUTPUT
+      - name: Muestra outputs de steps anteriores para debugueo
+        env:
+          CHANGED_PO_FILES: ${{ toJson(steps.changed-po-files) }}
+          PO_FILES_TO_CHECK: ${{ toJson(steps.po-files-to-check) }}
+        run: |
+          echo "$PO_FILES_TO_CHECK"
+          echo "$CHANGED_PO_FILES"
 
       # Chequeos a realizar
       - name: TRANSLATORS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
+      - name: Configura dpkg/apt para correr de manera eficiente
+        uses: abbbi/github-actions-tune@v1
+      - name: Deshabilita triggers de postgresql-common
+        run: sudo sed -i '/postgresql-common/d' /var/lib/dpkg/triggers/File
       - name: Instalar dependencias de sistema
         run: |
           sudo apt-get update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-          # Necesario para que tj-actions/changed-files corra
+          # Necesario para que tj-actions/changed-files se ejecute
           # dentro de un tiempo adecuado
           fetch-depth: 2
 
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
-      - name: Configura dpkg/apt para correr de manera eficiente
+      - name: Configura dpkg/apt para ejecutarse de manera eficiente
         uses: abbbi/github-actions-tune@v1
       - name: Deshabilita triggers de postgresql-common
         run: sudo sed -i '/postgresql-common/d' /var/lib/dpkg/triggers/File

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,13 +72,14 @@ jobs:
         run: |
           diff -Naur TRANSLATORS <(LANG=es python scripts/sort.py < TRANSLATORS)
       - name: Powrap
-        run: powrap --check --quiet **/*.po
+        if: steps.po-files-to-check.outputs.any_po_files_to_check == 'true'
+        run: powrap --check --quiet ${{ steps.po-files-to-check.outputs.po_files_to_check }}
       - name: Sphinx lint
-        run: |
-          sphinx-lint */*.po
+        if: steps.po-files-to-check.outputs.any_po_files_to_check == 'true'
+        run: sphinx-lint ${{ steps.po-files-to-check.outputs.po_files_to_check }}
       - name: Pospell
-        run: |
-          python scripts/check_spell.py
+        if: steps.po-files-to-check.outputs.any_po_files_to_check == 'true'
+        run: python scripts/check_spell.py ${{ steps.po-files-to-check.outputs.po_files_to_check }}
 
       # Construcción de la documentación
       - name: Construir documentación

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,8 +64,8 @@ jobs:
           CHANGED_PO_FILES: ${{ toJson(steps.changed-po-files) }}
           PO_FILES_TO_CHECK: ${{ toJson(steps.po-files-to-check) }}
         run: |
-          echo "$PO_FILES_TO_CHECK"
-          echo "$CHANGED_PO_FILES"
+          echo "steps.changed-po-files=$PO_FILES_TO_CHECK"
+          echo "steps.po-files-to-change.$CHANGED_PO_FILES"
 
       # Chequeos a realizar
       - name: TRANSLATORS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,12 @@ jobs:
     name: Test
     runs-on: ubuntu-22.04
     steps:
+      # Obtención del código
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
+
+      # Instalación de dependencias
       - name: Preparar Python v3.11
         uses: actions/setup-python@v4
         with:
@@ -31,6 +34,8 @@ jobs:
           pip list
           pospell --version
           powrap --version
+
+      # Chequeos a realizar
       - name: TRANSLATORS
         run: |
           diff -Naur TRANSLATORS <(LANG=es python scripts/sort.py < TRANSLATORS)
@@ -42,6 +47,8 @@ jobs:
       - name: Pospell
         run: |
           python scripts/check_spell.py
+
+      # Construcción de la documentación
       - name: Construir documentación
         run: |
           # FIXME: Relative paths for includes in 'cpython'


### PR DESCRIPTION
Este PR modifica el job `Test` del workflow `Test` (i.e., el pipeline que se corre en cada PR y push a 3.12) con los siguientes cambios:
 * Checkout del submodule cpython se hace como parte de `actions/checkout` (no hay beneficio en hacerlo por cuentra propia)
 * Re-agrupa y comenta los distintos pasos del workflow
 * Configure apt and dpkg para correr de manera más eficiente, evitando la ejecución de algunos triggers que son innecesarios y que consumen CPU.
 * Instala `locales-all` para evitar la generación de los locales en español, ya que esta generación consume un largo tiempo de CPU, mientras que bajar el paquete es mucho más rápido. También se evita correr `apt update`.
 * Por último, y lo más complejo: cuando el workflow corre como parte de un PR, se calculan los archivos .po que han cambiado dentro del PR, y se corren los chequeos (sphinx-lint, powrap, pospell) sólo sobre estos archivos. Si el workflow corre como parte de un push a 3.12 todos los archivos se chequean.