### PR TITLE
Marca issues/PRs como stale sólo si tiene alguien asignado

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -16,3 +16,4 @@ jobs:
           days-before-pr-close: 21
           stale-issue-message: "Este issue lleva un tiempo sin actualizaciones. ¿Estás trabajando todavía?\nSi necesitas ayuda :sos: no dudes en contactarnos en nuestro [grupo de Telegram](https://t.me/python_docs_es)."
           stale-pr-message: "Este PR lleva un tiempo sin actualizaciones. Vamos a pedir a un admin de nuestro equipo que decida si alguien más puede finalizarlo o si tenemos que cerrarlo.\nPor favor, avisanos en caso de que aún puedas terminarlo."
+          include-only-assigned: true


### PR DESCRIPTION
Opción descrita en https://github.com/actions/stale#include-only-assigned