### PR TITLE
Agrega comentario a PR con entradas faltantes

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,45 @@
+name: Agrega comentario a PR
+
+on:
+  pull_request_target:
+
+jobs:
+  pr-comment:
+    name: Entradas sin traducción
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          persist-credentials: false
+      - name: Preparar Python v3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Instalar dependencias
+        run: |
+          python -m pip install -r requirements.txt
+      - name: Obtiene lista de archivos con cambios
+        id: changed-files
+        uses: tj-actions/changed-files@v39
+        with:
+          files: |
+            **/*.po
+      - name: Calcular entradas faltantes
+        if: steps.changed-files.outputs.any_changed == 'true'
+        id: create-pr-comment
+        env:
+          CHANGED_PO_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          {
+            echo 'comment<<EOF'
+            python scripts/list_missing_entries.py --github $CHANGED_PO_FILES
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Agregar comentario con entradas faltantes
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: ${{ steps.create-pr-comment.outputs.comment }}
+          comment_tag: missing-entries

--- a/scripts/list_missing_entries.py
+++ b/scripts/list_missing_entries.py
@@ -1,0 +1,55 @@
+import argparse
+import dataclasses
+import enum
+import glob
+import itertools
+import os
+
+import polib
+import tabulate
+
+
+class MissingReason(enum.StrEnum):
+    FUZZY = "fuzzy"
+    UNTRANSLATED = "untranslated"
+
+    @staticmethod
+    def from_poentry(poentry: polib.POEntry):
+        if poentry.fuzzy:
+            return MissingReason.FUZZY
+        assert not poentry.translated()
+        return MissingReason.UNTRANSLATED
+
+@dataclasses.dataclass
+class MissingEntry:
+    reason: MissingReason
+    file: str
+    line: int
+
+    @staticmethod
+    def from_poentry(pofilename: str, poentry: polib.POEntry) -> "MissingEntry":
+        return MissingEntry(MissingReason.from_poentry(poentry), pofilename, poentry.linenum)
+
+
+def find_missing_entries(filename: str) -> list[MissingEntry]:
+    po = polib.pofile(filename)
+    fuzzy = po.fuzzy_entries()
+    untranslated = po.untranslated_entries()
+    return [MissingEntry.from_poentry(filename, entry) for entry in fuzzy + untranslated]
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("files", nargs="+")
+    parser.add_argument("-g", "--github-mode", help="Produce output as a GitHub comment", action='store_true')
+    opts = parser.parse_args()
+    missing_entries = list(itertools.chain.from_iterable(map(find_missing_entries, opts.files)))
+    if not missing_entries:
+        print(f"All entries translated, horray!{' :tada:' if opts.github_mode else ''}")
+    else:
+        missing_entries.sort(key = lambda entry: (entry.file, entry.line))
+        print("Entries missing translation, details follow:\n")
+        print(tabulate.tabulate(missing_entries,headers=["Reason", "File", "Line"], tablefmt="github"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Este PR agrega una nueva acción que agrega un comentario a los PRs que editan archivos .po indicando qué entradas aún no tienen una traducción.

Un ejemplo de esto funcionando se puede ver en https://github.com/rtobar/python-docs-es/pull/3. Hay varios comentarios automáticos porque use ese PR para debuguear el proceso, pero la idea es que finalmente haya un solo comentario que se va actualizando (como se puede ver en el último comentario, que está editado).

Otro ejemplo se puede ver en https://github.com/rtobar/python-docs-es/pull/5, donde el PR viene desde un fork en vez de venir desde el mismo repositorio.

Otra opción habría sido agregar un check a CI que falle si faltan entradas, pero en 3.11 ya tuvimos el caso en que *tuvimos* que dejar entradas fuzzy a propósito.