### PR TITLE
Ejecuta apt update antes de apt install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: sudo sed -i '/postgresql-common/d' /var/lib/dpkg/triggers/File
       - name: Instalar dependencias de sistema
         run: |
-          sudo apt-get install -y hunspell hunspell-es gettext language-pack-es locales-all
+          sudo apt-get update && apt-get install -y hunspell hunspell-es gettext language-pack-es locales-all
       - name: Instalar dependencias de Python
         run: |
           python -m pip install -r requirements.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,8 @@ jobs:
         run: sudo sed -i '/postgresql-common/d' /var/lib/dpkg/triggers/File
       - name: Instalar dependencias de sistema
         run: |
-          sudo apt-get update && sudo apt-get install -y hunspell hunspell-es gettext language-pack-es locales-all
+          sudo apt-get update
+          sudo apt-get install -y hunspell hunspell-es gettext language-pack-es locales-all
       - name: Instalar dependencias de Python
         run: |
           python -m pip install -r requirements.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: sudo sed -i '/postgresql-common/d' /var/lib/dpkg/triggers/File
       - name: Instalar dependencias de sistema
         run: |
-          sudo apt-get update && apt-get install -y hunspell hunspell-es gettext language-pack-es locales-all
+          sudo apt-get update && sudo apt-get install -y hunspell hunspell-es gettext language-pack-es locales-all
       - name: Instalar dependencias de Python
         run: |
           python -m pip install -r requirements.txt


### PR DESCRIPTION
En 01f3d8c80d74c74ed15156f85d3f1e91a35bad81 supuse que apt update ya no era necesario, pero al parecer me dejé engañar por un falso positivo.