### PR TITLE
Corrijo error en un ejemplo de código

### DIFF
--- a/tutorial/stdlib.po
+++ b/tutorial/stdlib.po
@@ -97,8 +97,8 @@ msgid ""
 "Here is the output from running ``python demo.py one two three`` at the "
 "command line::"
 msgstr ""
-"Este es el resultado de ejecutar ``python demo.py uno dos tres`` en la línea "
-"de comandos::"
+"Este es el resultado de ejecutar ``python demo.py one two three`` en la "
+"línea de comandos::"
 
 #: ../Doc/tutorial/stdlib.rst:79
 msgid ""


### PR DESCRIPTION
Dejo el comando en inglés para que corresponda con la salida que se muestra en:
https://docs.python.org/es/3.12/tutorial/stdlib.html#command-line-arguments