### PR TITLE
Actualiza Sphinx a última versión, fija versión para sphinx-tabs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip
-Sphinx==4.5.0
+Sphinx==7.2.6
 blurb
 Pygments==2.16.1
 PyICU
@@ -13,6 +13,6 @@ sphinx-intl
 pre-commit
 sphinx-autorun
 sphinxemoji
-sphinx-tabs
+sphinx-tabs==3.4.4
 sphinx-lint==0.7.0
 tabulate


### PR DESCRIPTION
Localmente esta actualización resuelve el problema visto en https://github.com/python/python-docs-es/pull/2795 y reportado en el grupo de Telegram.