### PR TITLE
Fija versión para docutils y sphinx-tabs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ sphinx-intl
 pre-commit
 sphinx-autorun
 sphinxemoji
-sphinx-tabs==3.4.4
+sphinx-tabs==3.4.5
 sphinx-lint==0.7.0
 tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+docutils==0.20.1
 pip
 Sphinx==7.2.6
 blurb


### PR DESCRIPTION
Con esta actualización resolvemos el error visto en #2796.
Localmente corrió sin problemas.