### PR TITLE
Remove include:: replacements hack

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,5 @@ jobs:
       # Construcción de la documentación
       - name: Construir documentación
         run: |
-          make fix_relative_paths
           # Normal build
           PYTHONWARNINGS=ignore::FutureWarning,ignore::RuntimeWarning sphinx-build -j auto -W --keep-going -b html -d cpython/Doc/_build/doctree -D language=es . cpython/Doc/_build/html

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ help:
 #        before this. If passing SPHINXERRORHANDLING='', warnings will not be
 #        treated as errors, which is good to skip simple Sphinx syntax mistakes.
 .PHONY: build
-build: setup fix_relative_paths do_build
+build: setup do_build
 
 .PHONY: do_build
 do_build:
@@ -47,14 +47,6 @@ do_build:
 	PYTHONWARNINGS=ignore::FutureWarning,ignore::RuntimeWarning $(VENV)/bin/sphinx-build -j $(SPHINX_JOBS) -W --keep-going -b html -d $(OUTPUT_DOCTREE) -D language=$(LANGUAGE) . $(OUTPUT_HTML) && \
 		echo "Success! Open file://`pwd`/$(OUTPUT_HTML)/index.html, " \
 			"or run 'make serve' to see them in http://localhost:8000";
-
-.PHONY: fix_relative_paths
-fix_relative_paths:
-	# FIXME: Relative paths for includes in 'cpython'
-	# See more about this at https://github.com/python/python-docs-es/issues/1844
-	sed -i -e 's|.. include:: ../includes/wasm-notavail.rst|.. include:: ../../../../includes/wasm-notavail.rst|g' cpython/Doc/**/*.rst
-	sed -i -e 's|.. include:: token-list.inc|.. include:: ../../../token-list.inc|g' cpython/Doc/library/token.rst
-	sed -i -e 's|.. include:: /using/venv-create.inc|.. include:: ../../../../using/venv-create.inc|g' cpython/Doc/library/venv.rst
 
 # setup: After running "venv" target, prepare that virtual environment with
 #        a local clone of cpython repository and the translation files.

--- a/conf.py
+++ b/conf.py
@@ -129,7 +129,7 @@ def setup(app):
             document.insert(0, banner)
 
     # Change the sourcedir programmatically because Read the Docs always call it with `.`
-    app.srcdir = 'cpython/Doc'
+    app.srcdir = os.getcwd() + '/cpython/Doc'
 
     app.connect('doctree-read', add_contributing_banner)
 


### PR DESCRIPTION
We currently need to replace the include:: directives in the cpython documentation source files to fix an issue that sphinx/docutils have with relative source files after changing the app.srcdir in our conf.py.

Instead of doing this, let's define the app.srcdir property as an absolute path. This removes the issue altogether, yielding a correct build without the need to modify the documentation source files.

This change seems to have the nice side effect that successive builds are not incremental rather than starting from scratch.

Closes #1844 