### PR TITLE
3.13 build comments

### DIFF
--- a/.overrides/upgrade-python-version.rst
+++ b/.overrides/upgrade-python-version.rst
@@ -48,9 +48,11 @@ We are currently in branch 3.12, and we want to update the strings from 3.13.
 
    .. note::
 
-      You can also run `make build -j` to use more than 1 core (but keep in mind
-      this is not always faster).
+      The underlying ``sphinx-build`` command uses all available cores by default.
+      Use the ``SPHINX_JOBS`` ``make`` variable (defaults to ``auto``)
+      to specify an explicit amount, e.g. ``make build SPHINX_JOBS=10``.
 
+   .. note::
       It may fail the build because there may be files
       that don't exist anymore in the new branch.
       If that's the case, just continue with the steps

--- a/conf.py
+++ b/conf.py
@@ -29,15 +29,6 @@ sys.path.append(os.path.abspath('cpython/Doc/includes'))
 sys.path.insert(0, os.path.abspath('cpython/Doc'))
 from conf import *
 
-# FIXME
-# For fixing the warnings that state that 'cwe', 'cve' roles are already
-# defined.
-#
-# WARNING: role 'cve' is already registered, it will be overridden [app.add_role]
-# WARNING: role 'cwe' is already registered, it will be overridden [app.add_role]
-del extlinks["cwe"]
-del extlinks["cve"]
-
 # Call patchlevel with the proper path to get the version from
 # instead of hardcoding it
 from patchlevel import get_version_info

--- a/conf.py
+++ b/conf.py
@@ -29,14 +29,7 @@ sys.path.append(os.path.abspath('cpython/Doc/includes'))
 sys.path.insert(0, os.path.abspath('cpython/Doc'))
 from conf import *
 
-# Call patchlevel with the proper path to get the version from
-# instead of hardcoding it
-from patchlevel import get_version_info
-version, release = get_version_info()
-
 project = 'Python en Español'
-year = time.strftime("%Y")
-copyright = f'2001-{year}, Python Software Foundation'
 
 html_theme_path = ['cpython/Doc/tools']
 templates_path = ['cpython/Doc/tools/templates']

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ sphinx-lint==0.7.0
 tabulate
 
 # from cpython/Doc/requirements.txt
-sphinx~=8.1.0
+sphinx~=8.0.0
 
 blurb
 


### PR DESCRIPTION
Detalles en los mensajes de los commits

 * Clarifica el uso de `make build -j` (i.e.: NO usar)
 * Pinea `sphinx ~= 8.0.0`. En 8.1 agregaron los roles como built-in.
 * Remueve un par de settings en nuestro `conf.py` para reducir la brecha entre el nuestro y el de cpython