### PR TITLE
Arregla GHA que agrega comentario sobre entradas faltantes

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -30,11 +30,11 @@ jobs:
           path: base-branch
           sparse-checkout-cone-mode: false
           sparse-checkout: |
-            requirements.txt
+            requirements-own.txt
             scripts/list_missing_entries.py
       - name: Instalar dependencias
         run: |
-          python -m pip install -r base-branch/requirements.txt
+          python -m pip install -r base-branch/requirements-own.txt
       - name: Obtiene lista de archivos con cambios
         id: changed-files
         uses: tj-actions/changed-files@v45

--- a/requirements-own.txt
+++ b/requirements-own.txt
@@ -1,0 +1,16 @@
+# Our own dependencies (alpha-sorted please)
+pip
+polib
+pospell>=1.1
+potodo
+powrap>=1.0.2
+pre-commit
+Pygments>=2.17.0
+PyICU
+setuptools
+sphinx-autorun
+sphinxemoji
+sphinx-intl>=2.3.0
+sphinx-lint==0.7.0
+sphinx-tabs==3.4.5
+tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,2 @@
 -r cpython/Doc/requirements.txt
-
-# Our own dependencies (alpha-sorted please)
-pip
-polib
-pospell>=1.1
-potodo
-powrap>=1.0.2
-pre-commit
-Pygments>=2.17.0
-PyICU
-setuptools
-sphinx-autorun
-sphinxemoji
-sphinx-intl>=2.3.0
-sphinx-lint==0.7.0
-sphinx-tabs==3.4.5
-tabulate
+-r requirements-own.txt


### PR DESCRIPTION
La acción comenzó a fallar (e.g. https://github.com/python/python-docs-es/actions/runs/11980786740/job/33405766523?pr=3304) después de mergear https://github.com/python/python-docs-es/pull/3301. Esto porque la acción realiza un "sparse checkout" (para ahorrar tiempo) de ciertos archivos, y con #3301 este checkout hubiese tenido que haber incluido a todo el submódulo cpython, con lo cual se hubieran agregado varios seguidos más a la ejecución del GHA.

Este PR separa nuestras propias dependencias en un nuevo archivo `requirements-own.txt` que es incluido por `requirements.txt`, pero que también puede ser referenciado de forma separada. El GHA en cuestión efectivamente ahora sólo instala `requirements-own.txt`, evitando así referenciar al submódulo de cpython.

Por otro lado, tener nuestras propias dependencias en un archivo separado no es malo en términos de organización de la información.

Nótese que este PR en sí va a fallar, ya que el archivo .yaml definiendo el GHA fallido se toma de la rama principla, no la del PR. Pero en https://github.com/rtobar/python-docs-es/pull/9 pueden ver que el fix funciona al abrir un PR contra una rama donde el fix ya está puesto.