### PR TITLE
Bump dependency on sphinx-tabs

### DIFF
--- a/requirements-own.txt
+++ b/requirements-own.txt
@@ -12,5 +12,5 @@ sphinx-autorun
 sphinxemoji
 sphinx-intl>=2.3.0
 sphinx-lint==0.7.0
-sphinx-tabs==3.4.5
+sphinx-tabs==3.4.7
 tabulate


### PR DESCRIPTION
This latest patch release fixes a RemovedInSphinx90Warning that can be seen when building the docs without ignoring any warnings via PYTHONWARNINGS.

I'm working on a few fixes for sphinx-autorun too (see https://github.com/WhyNotHugo/sphinx-autorun/pulls), one of which removes some `RuntimeWarning`s. After those come in, we can finally remove the ignore warning filter we currently use via a `PYTHONWARNINGS` environment variable in `make do_build`.