### PR TITLE
Actualiza a sphinx-autorun >= 2.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,5 +91,4 @@ jobs:
       # Construcción de la documentación
       - name: Construir documentación
         run: |
-          # Normal build
-          PYTHONWARNINGS=ignore::FutureWarning,ignore::RuntimeWarning sphinx-build -j auto -W --keep-going -b html -d cpython/Doc/_build/doctree -D language=es . cpython/Doc/_build/html
+          sphinx-build -j auto -W --keep-going -b html -d cpython/Doc/_build/doctree -D language=es . cpython/Doc/_build/html

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ build: setup do_build
 .PHONY: do_build
 do_build:
 	# Normal build
-	PYTHONWARNINGS=ignore::FutureWarning,ignore::RuntimeWarning $(VENV)/bin/sphinx-build -j $(SPHINX_JOBS) -W --keep-going -b html -d $(OUTPUT_DOCTREE) -D language=$(LANGUAGE) . $(OUTPUT_HTML) && \
+	$(VENV)/bin/sphinx-build -j $(SPHINX_JOBS) -W --keep-going -b html -d $(OUTPUT_DOCTREE) -D language=$(LANGUAGE) . $(OUTPUT_HTML) && \
 		echo "Success! Open file://`pwd`/$(OUTPUT_HTML)/index.html, " \
 			"or run 'make serve' to see them in http://localhost:8000";
 

--- a/conf.py
+++ b/conf.py
@@ -54,6 +54,7 @@ else:
     exclude_patterns  = _exclude_patterns
 
 _extensions = [
+    'sphinx_autorun',
     'sphinx_tabs.tabs',
     'sphinxemoji.sphinxemoji',
 ]
@@ -126,22 +127,3 @@ def setup(app):
     app.srcdir = Path(os.getcwd() + '/cpython/Doc')
 
     app.connect('doctree-read', add_contributing_banner)
-
-    # Import the sphinx-autorun manually to avoid this warning
-    # TODO: Remove this code and use just ``extensions.append('sphinx_autorun')`` when
-    # that issue gets fixed
-    # See https://github.com/WhyNotHugo/sphinx-autorun/issues/17
-
-    # WARNING: the sphinx_autorun extension does not declare if it is safe for
-    # parallel reading, assuming it isn't - please ask the extension author to
-    # check and make it explicit
-    # WARNING: doing serial read
-    from sphinx_autorun import RunBlock, AutoRun
-    app.add_directive('runblock', RunBlock)
-    app.connect('builder-inited', AutoRun.builder_init)
-    app.add_config_value('autorun_languages', AutoRun.config, 'env')
-    return {
-        'version': '0.1',
-        'parallel_read_safe': True,
-        'parallel_write_safe': True,
-    }

--- a/requirements-own.txt
+++ b/requirements-own.txt
@@ -8,7 +8,7 @@ pre-commit
 Pygments>=2.17.0
 PyICU
 setuptools
-sphinx-autorun
+sphinx-autorun>=2.0.0
 sphinxemoji
 sphinx-intl>=2.3.0
 sphinx-lint==0.7.0


### PR DESCRIPTION
Esta última versión incluye dos correcciones importantes: 1) la extensión ahora declara que sphinx puede llevar a cabo la lectura de los archivos .rst en paralelo (https://github.com/WhyNotHugo/sphinx-autorun/pull/63), y 2) elimina unos RuntimeWarnings producto de un mal uso de la opción bufsize al crear objetos Popen (https://github.com/WhyNotHugo/sphinx-autorun/pull/65).

El primero de los problemas conllevaba a que nosotros tuviéramos que realizar manualmente el registro del plug-in, en vez de simplemente declararlo en "extensions". El segundo problema nos llevó a fijar un filtro con PYTHONWARNINGS con el cual se ignoraban todos los RuntimeWarning. Con esta última versión de sphinx-autorun, ambas soluciones parches ya no son necesarias.