### PR TITLE
Pin hash to a previous version in order to avoid the exploit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Obtiene la lista de archivos .po con cambios (sólo en PRs)
         if: github.event_name == 'pull_request'
         id: changed-po-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
         with:
           files: |
              **/*.po

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -37,7 +37,7 @@ jobs:
           python -m pip install -r base-branch/requirements-own.txt
       - name: Obtiene lista de archivos con cambios
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
         with:
           files: |
             **/*.po


### PR DESCRIPTION
This uses another version (v44) where I could find the hash (we currently used v45).

In summary, the repo got compromised and all the tags versions point to a malicius commit that includes a function to expose the secrets on the github action logs, so people can fetch them.