### PR TITLE
Upgrade tj-actions to v46 per security recommendations.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Obtiene la lista de archivos .po con cambios (sólo en PRs)
         if: github.event_name == 'pull_request'
         id: changed-po-files
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
+        uses: tj-actions/changed-files@v46
         with:
           files: |
              **/*.po

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -37,7 +37,7 @@ jobs:
           python -m pip install -r base-branch/requirements-own.txt
       - name: Obtiene lista de archivos con cambios
         id: changed-files
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
+        uses: tj-actions/changed-files@v46
         with:
           files: |
             **/*.po


### PR DESCRIPTION
Per discussion in issue https://github.com/python/python-docs-es/issues/3373, this PR update `tj-actions/changed-files` to its latest version [v46](https://github.com/tj-actions/changed-files/releases/tag/v46.0.3).

Related PR: https://github.com/python/python-docs-es/pull/3374

Supersedes https://github.com/python/python-docs-es/pull/3377