### PR TITLE
Actualizar paso 5 en archivo CONTRIBUTING

### DIFF
--- a/.overrides/CONTRIBUTING.rst
+++ b/.overrides/CONTRIBUTING.rst
@@ -54,9 +54,9 @@ podrás realizar todas las contribuciones que quieras.
 
 #. (Opcional) Crea un entorno virtual y actívalo::
 
-     python -m venv env
-     source env/bin/activate   # macOS y Linux
-     env\Scripts\activate.bat  # Windows
+     python -m venv venv
+     source venv/bin/activate   # macOS y Linux
+     venv\Scripts\activate.bat  # Windows
 
 #. (Opcional) Instala los requerimientos del proyecto::
 


### PR DESCRIPTION
Encontré una falla en el paso 5 (opcional) de la documentación para contribuir. El Makefile apunta al directorio **venv** y el comando de python crea un directorio nombrado **env**.

Snip del código:

```
#
# Makefile for Spanish Python Documentation
# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
...
# Internal variables
VENV                := $(shell realpath ./venv)
PYTHON              := $(shell which python3)
...
```

Probé la guia siguiendo los pasos actuales y resulta en un error, cambiando el comando y el _source path_ por **venv** se solucionan los errores.