### PR TITLE
Lint fixes

### DIFF
--- a/howto/enum.po
+++ b/howto/enum.po
@@ -32,7 +32,7 @@ msgid ""
 msgstr ""
 "Un :class:`Enum` es un conjunto de nombres simbólicos vinculados a valores "
 "únicos. Son similares a las variables globales, pero ofrecen un :func:"
-"`repr()` más útil, agrupación, seguridad de tipos y algunas otras "
+"`repr` más útil, agrupación, seguridad de tipos y algunas otras "
 "características."
 
 #: ../Doc/howto/enum.rst:15
@@ -412,7 +412,7 @@ msgid ""
 "yourself some work and use :func:`auto` for the values::"
 msgstr ""
 "En los casos en que los valores reales de los miembros no importen, puede "
-"ahorrarse algo de trabajo y usar :func:`auto()` para los valores:"
+"ahorrarse algo de trabajo y usar :func:`auto` para los valores:"
 
 #: ../Doc/howto/enum.rst:172
 msgid ""


### PR DESCRIPTION
From [dashboard](https://python-docs-translations.github.io/dashboard/warnings-lint-es.txt)

```
clones/rebased_translations/python/python-docs-es/howto/enum.po:27: Unnecessary parentheses in ':func:`repr()`' (unnecessary-parentheses)
clones/rebased_translations/python/python-docs-es/howto/enum.po:391: Unnecessary parentheses in ':func:`auto()`' (unnecessary-parentheses)
```