### PR TITLE
Fix lint

### DIFF
--- a/c-api/refcounting.po
+++ b/c-api/refcounting.po
@@ -47,7 +47,7 @@ msgid ""
 msgstr ""
 "Ten cuenta que el valor devuelto puede que no reflejar cúantas referencias "
 "al objecto existen realmente. Por ejemplo, algunos objetos son :"
-"term:'immortal' y tienen un refcount muy alto que no refleja el número "
+"term:`immortal` y tienen un refcount muy alto que no refleja el número "
 "real de referencias. Por lo tanto, no confíes en que el valor devuelto sea "
 "presciso, salvo cuando sea 0 o 1. "
 
@@ -172,6 +172,8 @@ msgid ""
 "Py_INCREF(obj);\n"
 "self->attr = obj;"
 msgstr ""
+"Py_INCREF(obj);\n"
+"self->attr = obj;"
 
 #: ../Doc/c-api/refcounting.rst:96
 msgid "can be written as::"


### PR DESCRIPTION
```
clones/rebased_translations/python/python-docs-es/c-api/refcounting.po:40: role with no backticks: " :term:'immortal' " (role-without-backticks)
clones/rebased_translations/python/python-docs-es/c-api/refcounting.po:40: trailing whitespace (trailing-whitespace)
clones/rebased_translations/python/python-docs-es/c-api/refcounting.po:92: trailing whitespace (trailing-whitespace)
clones/rebased_translations/python/python-docs-es/c-api/refcounting.po:269: trailing whitespace (trailing-whitespace)
```
I could only find the first one in the gh editor:-( Bonus translation though:-)