### PR TITLE
Translate `c-api/tuple.po` 🤖

### DIFF
--- a/c-api/tuple.po
+++ b/c-api/tuple.po
@@ -11,8 +11,7 @@ msgstr ""
 "Project-Id-Version: Python 3.8\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-21 16:38-0300\n"
-"PO-Revision-Date: 2022-10-29 23:58-0400\n"
-"Last-Translator: Rodrigo Tobar <rtobarc@gmail.com>\n"
+"Last-Translator: Erick G. Islas-Osuna <erickisos653@gmail.com>\n"
 "Language: es\n"
 "Language-Team: python-doc-es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
@@ -55,43 +54,42 @@ msgstr ""
 "subtipo del tipo tupla. Esta función siempre finaliza con éxito."
 
 #: ../Doc/c-api/tuple.rst:36
-#, fuzzy
 msgid ""
 "Return a new tuple object of size *len*, or ``NULL`` with an exception set "
 "on failure."
 msgstr ""
-"Retorna un nuevo objeto tupla de tamaño *len* o ``NULL`` en caso de falla."
+"Retorna un nuevo objeto tupla de tamaño *len*, o ``NULL`` con una excepción establecida "
+"en caso de falla."
 
 #: ../Doc/c-api/tuple.rst:42
-#, fuzzy
 msgid ""
 "Return a new tuple object of size *n*, or ``NULL`` with an exception set on "
 "failure. The tuple values are initialized to the subsequent *n* C arguments "
 "pointing to Python objects. ``PyTuple_Pack(2, a, b)`` is equivalent to "
 "``Py_BuildValue(\"(OO)\", a, b)``."
 msgstr ""
-"Retorna un nuevo objeto tupla de tamaño *n*, o ``NULL`` en caso de falla. "
-"Los valores de tupla se inicializan en los argumentos C posteriores *n* que "
-"apuntan a objetos de Python. ``PyTuple_Pack (2, a, b)`` es equivalente a "
+"Retorna un nuevo objeto tupla de tamaño *n*, o ``NULL`` con una excepción establecida en "
+"caso de falla. Los valores de tupla se inicializan con los siguientes *n* argumentos C "
+"que apuntan a objetos de Python. ``PyTuple_Pack(2, a, b)`` es equivalente a "
 "``Py_BuildValue(\"(OO)\", a, b)``."
 
 #: ../Doc/c-api/tuple.rst:50
-#, fuzzy
 msgid ""
 "Take a pointer to a tuple object, and return the size of that tuple. On "
 "error, return ``-1`` and with an exception set."
-msgstr "Toma un puntero a un objeto de tupla y retorna el tamaño de esa tupla."
+msgstr ""
+"Toma un puntero a un objeto tupla y retorna el tamaño de esa tupla. En caso "
+"de error, retorna ``-1`` con una excepción establecida."
 
 #: ../Doc/c-api/tuple.rst:56
-#, fuzzy
 msgid "Like :c:func:`PyTuple_Size`, but without error checking."
-msgstr "Como :c:func:`PyTuple_GetItem`, pero no verifica sus argumentos."
+msgstr "Como :c:func:`PyTuple_Size`, pero sin verificación de errores."
 
 #: ../Doc/c-api/tuple.rst:61
 msgid ""
 "Return the object at position *pos* in the tuple pointed to by *p*.  If "
-"*pos* is negative or out of bounds, return ``NULL`` and set an :exc:"
-"`IndexError` exception."
+"*pos* is negative or out of bounds, return ``NULL`` and set "
+"an :exc:`IndexError` exception."
 msgstr ""
 "Retorna el objeto en la posición *pos* en la tupla señalada por *p*. Si "
 "*pos* es negativo o está fuera de los límites, retorna ``NULL`` y establece "
@@ -101,9 +99,13 @@ msgstr ""
 msgid ""
 "The returned reference is borrowed from the tuple *p* (that is: it is only "
 "valid as long as you hold a reference to *p*). To get a :term:`strong "
-"reference`, use :c:func:`Py_NewRef(PyTuple_GetItem(...)) <Py_NewRef>` or :c:"
-"func:`PySequence_GetItem`."
+"reference`, use :c:func:`Py_NewRef(PyTuple_GetItem(...)) <Py_NewRef>` "
+"or :c:func:`PySequence_GetItem`."
 msgstr ""
+"La referencia retornada es prestada de la tupla *p* (es decir: solo es "
+"válida mientras mantengas una referencia a *p*). Para obtener una :term:`referencia "
+"fuerte`, usa :c:func:`Py_NewRef(PyTuple_GetItem(...)) <Py_NewRef>` "
+"o :c:func:`PySequence_GetItem`."
 
 #: ../Doc/c-api/tuple.rst:73
 msgid "Like :c:func:`PyTuple_GetItem`, but does no checking of its arguments."
@@ -114,16 +116,16 @@ msgid ""
 "Return the slice of the tuple pointed to by *p* between *low* and *high*, or "
 "``NULL`` with an exception set on failure."
 msgstr ""
+"Retorna la rebanada de la tupla apuntada por *p* entre *low* y *high*, o "
+"``NULL`` con una excepción establecida en caso de falla."
 
 #: ../Doc/c-api/tuple.rst:81
-#, fuzzy
 msgid ""
 "This is the equivalent of the Python expression ``p[low:high]``. Indexing "
 "from the end of the tuple is not supported."
 msgstr ""
-"Retorna la porción de la tupla señalada por *p* entre *low* y *high*, o "
-"``NULL`` en caso de falla. Este es el equivalente de la expresión de Python "
-"``p[low:high]``. La indexación desde el final de la tupla no es compatible."
+"Esto es equivalente a la expresión de Python ``p[low:high]``. La indexación "
+"desde el final de la tupla no es compatible."
 
 #: ../Doc/c-api/tuple.rst:87
 msgid ""
@@ -154,20 +156,25 @@ msgstr ""
 #: ../Doc/c-api/tuple.rst:102 ../Doc/c-api/tuple.rst:217
 #: ../Doc/c-api/tuple.rst:235
 msgid ""
-"Bounds checking is performed as an assertion if Python is built in :ref:"
-"`debug mode <debug-build>` or :option:`with assertions <--with-assertions>`."
+"Bounds checking is performed as an assertion if Python is built "
+"in :ref:`debug mode <debug-build>` or :option:`with assertions <--with-"
+"assertions>`."
 msgstr ""
+"La comprobación de límites se realiza como una aserción si Python se "
+"construye en :ref:`modo de depuración <debug-build>` o :option:`con "
+"aserciones <--with-assertions>`."
 
 #: ../Doc/c-api/tuple.rst:107
 msgid ""
-"This function \"steals\" a reference to *o*, and, unlike :c:func:"
-"`PyTuple_SetItem`, does *not* discard a reference to any item that is being "
-"replaced; any reference in the tuple at position *pos* will be leaked."
+"This function \"steals\" a reference to *o*, and, "
+"unlike :c:func:`PyTuple_SetItem`, does *not* discard a reference to any item "
+"that is being replaced; any reference in the tuple at position *pos* will be "
+"leaked."
 msgstr ""
-"Esta función \"roba\" una referencia a *o* y, a diferencia de :c:func:"
-"`PyTuple_SetItem`, *no* descarta una referencia a ningún elemento que se "
-"está reemplazando; cualquier referencia en la tupla en la posición *pos* se "
-"filtrará."
+"Esta función \"roba\" una referencia a *o* y, a diferencia "
+"de :c:func:`PyTuple_SetItem`, *no* descarta una referencia a ningún elemento "
+"que se está reemplazando; cualquier referencia en la tupla en la posición "
+"*pos* se filtrará."
 
 #: ../Doc/c-api/tuple.rst:115
 msgid ""
@@ -180,8 +187,8 @@ msgid ""
 "Client code should never assume that the resulting value of ``*p`` will be "
 "the same as before calling this function. If the object referenced by ``*p`` "
 "is replaced, the original ``*p`` is destroyed.  On failure, returns ``-1`` "
-"and sets ``*p`` to ``NULL``, and raises :exc:`MemoryError` or :exc:"
-"`SystemError`."
+"and sets ``*p`` to ``NULL``, and raises :exc:`MemoryError` "
+"or :exc:`SystemError`."
 msgstr ""
 "Se puede usar para cambiar el tamaño de una tupla. *newsize* será el nuevo "
 "tamaño de la tupla. Debido a que se *supone* que las tuplas son inmutables, "
@@ -201,10 +208,10 @@ msgstr "Objetos de secuencia de estructura"
 
 #: ../Doc/c-api/tuple.rst:132
 msgid ""
-"Struct sequence objects are the C equivalent of :func:`~collections."
-"namedtuple` objects, i.e. a sequence whose items can also be accessed "
-"through attributes. To create a struct sequence, you first have to create a "
-"specific struct sequence type."
+"Struct sequence objects are the C equivalent "
+"of :func:`~collections.namedtuple` objects, i.e. a sequence whose items can "
+"also be accessed through attributes. To create a struct sequence, you first "
+"have to create a specific struct sequence type."
 msgstr ""
 "Los objetos de secuencia de estructura son el equivalente en C de los "
 "objetos :func:`~collections.namedtuple`, es decir, una secuencia a cuyos "
@@ -215,8 +222,8 @@ msgstr ""
 #: ../Doc/c-api/tuple.rst:139
 msgid ""
 "Create a new struct sequence type from the data in *desc*, described below. "
-"Instances of the resulting type can be created with :c:func:"
-"`PyStructSequence_New`."
+"Instances of the resulting type can be created "
+"with :c:func:`PyStructSequence_New`."
 msgstr ""
 "Crea un nuevo tipo de secuencia de estructura a partir de los datos en "
 "*desc*, que se describen a continuación. Las instancias del tipo resultante "
@@ -224,7 +231,7 @@ msgstr ""
 
 #: ../Doc/c-api/tuple.rst:142 ../Doc/c-api/tuple.rst:210
 msgid "Return ``NULL`` with an exception set on failure."
-msgstr ""
+msgstr "Retorna ``NULL`` con una excepción establecida en caso de falla."
 
 #: ../Doc/c-api/tuple.rst:147
 msgid "Initializes a struct sequence type *type* from *desc* in place."
@@ -232,13 +239,12 @@ msgstr ""
 "Inicializa una secuencia de estructura tipo *type* desde *desc* en su lugar."
 
 #: ../Doc/c-api/tuple.rst:152
-#, fuzzy
 msgid ""
 "Like :c:func:`PyStructSequence_InitType`, but returns ``0`` on success and "
 "``-1`` with an exception set on failure."
 msgstr ""
-"Lo mismo que ``PyStructSequence_InitType``, pero retorna ``0`` en caso de "
-"éxito y ``-1`` en caso de error."
+"Como :c:func:`PyStructSequence_InitType`, pero retorna ``0`` en caso de "
+"éxito y ``-1`` con una excepción establecida en caso de falla."
 
 #: ../Doc/c-api/tuple.rst:160
 msgid "Contains the meta information of a struct sequence type to create."
@@ -267,21 +273,22 @@ msgstr ""
 #: ../Doc/c-api/tuple.rst:181
 msgid ""
 "Describes a field of a struct sequence. As a struct sequence is modeled as a "
-"tuple, all fields are typed as :c:expr:`PyObject*`.  The index in the :c:"
-"member:`~PyStructSequence_Desc.fields` array of the :c:type:"
-"`PyStructSequence_Desc` determines which field of the struct sequence is "
-"described."
+"tuple, all fields are typed as :c:expr:`PyObject*`.  The index in "
+"the :c:member:`~PyStructSequence_Desc.fields` array of "
+"the :c:type:`PyStructSequence_Desc` determines which field of the struct "
+"sequence is described."
 msgstr ""
 "Describe un campo de una secuencia de estructura. Como una secuencia de "
-"estructura se modela como una tupla, todos los campos se escriben como :c:"
-"expr:`PyObject*`. El índice en el arreglo :c:member:`~PyStructSequence_Desc."
-"fields` de :c:type:`PyStructSequence_Desc` determina qué campo de la "
-"secuencia de estructura se describe."
+"estructura se modela como una tupla, todos los campos se escriben "
+"como :c:expr:`PyObject*`. El índice en el "
+"arreglo :c:member:`~PyStructSequence_Desc.fields` "
+"de :c:type:`PyStructSequence_Desc` determina qué campo de la secuencia de "
+"estructura se describe."
 
 #: ../Doc/c-api/tuple.rst:189
 msgid ""
-"Name for the field or ``NULL`` to end the list of named fields, set to :c:"
-"data:`PyStructSequence_UnnamedField` to leave unnamed."
+"Name for the field or ``NULL`` to end the list of named fields, set "
+"to :c:data:`PyStructSequence_UnnamedField` to leave unnamed."
 msgstr ""
 "Nombre para el campo o ``NULL`` para finalizar la lista de campos con "
 "nombre, establece en :c:data:`PyStructSequence_UnnamedField` para dejar sin "
@@ -301,29 +308,26 @@ msgstr "El tipo se cambió de ``char *``."
 
 #: ../Doc/c-api/tuple.rst:207
 msgid ""
-"Creates an instance of *type*, which must have been created with :c:func:"
-"`PyStructSequence_NewType`."
+"Creates an instance of *type*, which must have been created "
+"with :c:func:`PyStructSequence_NewType`."
 msgstr ""
-"Crea una instancia de *type*, que debe haberse creado con :c:func:"
-"`PyStructSequence_NewType`."
+"Crea una instancia de *type*, que debe haberse creado "
+"con :c:func:`PyStructSequence_NewType`."
 
 #: ../Doc/c-api/tuple.rst:215
-#, fuzzy
 msgid ""
 "Return the object at position *pos* in the struct sequence pointed to by *p*."
 msgstr ""
 "Retorna el objeto en la posición *pos* en la secuencia de estructura "
-"apuntada por *p*. No se realiza la comprobación de límites."
+"apuntada por *p*."
 
 #: ../Doc/c-api/tuple.rst:223
-#, fuzzy
 msgid "Alias to :c:func:`PyStructSequence_GetItem`."
-msgstr "Macro equivalente de :c:func:`PyStructSequence_GetItem`."
+msgstr "Alias de :c:func:`PyStructSequence_GetItem`."
 
 #: ../Doc/c-api/tuple.rst:225
-#, fuzzy
 msgid "Now implemented as an alias to :c:func:`PyStructSequence_GetItem`."
-msgstr "Macro equivalente de :c:func:`PyStructSequence_GetItem`."
+msgstr "Ahora implementado como un alias de :c:func:`PyStructSequence_GetItem`."
 
 #: ../Doc/c-api/tuple.rst:231
 msgid ""
@@ -340,19 +344,17 @@ msgid "This function \"steals\" a reference to *o*."
 msgstr "Esta función \"roba\" una referencia a *o*."
 
 #: ../Doc/c-api/tuple.rst:245
-#, fuzzy
 msgid "Alias to :c:func:`PyStructSequence_SetItem`."
-msgstr "Macro equivalente de :c:func:`PyStructSequence_GetItem`."
+msgstr "Alias de :c:func:`PyStructSequence_SetItem`."
 
 #: ../Doc/c-api/tuple.rst:247
-#, fuzzy
 msgid "Now implemented as an alias to :c:func:`PyStructSequence_SetItem`."
-msgstr "Macro equivalente de :c:func:`PyStructSequence_GetItem`."
+msgstr "Ahora implementado como un alias de :c:func:`PyStructSequence_SetItem`."
 
 #: ../Doc/c-api/tuple.rst:8
 msgid "object"
-msgstr "object"
+msgstr "objeto"
 
 #: ../Doc/c-api/tuple.rst:8
 msgid "tuple"
-msgstr "tuple"
+msgstr "tupla"


### PR DESCRIPTION
Fixed missing msgstr entries for c-api/tuple.po:
- Tuple object type descriptions
- PyTypeObject instance descriptions
- Tuple type checking functions

Updated Last-Translator field and Po-Revision-Date.

Closes #3256